### PR TITLE
Use standard '_t' fixed-width types instead of rolling our own, where available

### DIFF
--- a/src/core/archive.cpp
+++ b/src/core/archive.cpp
@@ -80,25 +80,25 @@ TSTRING eArchiveCrypto::GetMsg() const
 // running out of memory or disk space.
 //
 
-void cArchive::ReadInt16(int16& ret) // throw(eArchive)
+void cArchive::ReadInt16(int16_t& ret) // throw(eArchive)
 {
-    if (ReadBlob(&ret, sizeof(int16)) != sizeof(int16))
+    if (ReadBlob(&ret, sizeof(int16_t)) != sizeof(int16_t))
         throw eArchiveEOF();
 
     ret = tw_ntohs(ret);
 }
 
-void cArchive::ReadInt32(int32& ret) // throw(eArchive)
+void cArchive::ReadInt32(int32_t& ret) // throw(eArchive)
 {
-    if (ReadBlob(&ret, sizeof(int32)) != sizeof(int32))
+    if (ReadBlob(&ret, sizeof(int32_t)) != sizeof(int32_t))
         throw eArchiveEOF();
 
     ret = tw_ntohl(ret);
 }
 
-void cArchive::ReadInt64(int64& ret) // throw(eArchive)
+void cArchive::ReadInt64(int64_t& ret) // throw(eArchive)
 {
-    if (ReadBlob(&ret, sizeof(int64)) != sizeof(int64))
+    if (ReadBlob(&ret, sizeof(int64_t)) != sizeof(int64_t))
         throw eArchiveEOF();
 
     ret = tw_ntohll(ret);
@@ -112,7 +112,7 @@ void cArchive::ReadInt64(int64& ret) // throw(eArchive)
 void cArchive::ReadString(TSTRING& ret) // throw(eArchive)
 {
     // read in size of string
-    int16 size;
+    int16_t size;
     ReadInt16(size);
 
     // create buffer for WCHAR16 string
@@ -122,7 +122,7 @@ void cArchive::ReadString(TSTRING& ret) // throw(eArchive)
 
     for (int n = 0; n < size; n++)
     {
-        int16 i16;
+        int16_t i16;
         ReadInt16(i16);
         *pwc++ = i16;
     }
@@ -136,22 +136,22 @@ int cArchive::ReadBlob(void* pBlob, int count)
     return Read(pBlob, count);
 }
 
-void cArchive::WriteInt16(int16 i) // throw(eArchive)
+void cArchive::WriteInt16(int16_t i) // throw(eArchive)
 {
     i = tw_htons(i);
-    WriteBlob(&i, sizeof(int16));
+    WriteBlob(&i, sizeof(int16_t));
 }
 
-void cArchive::WriteInt32(int32 i) // throw(eArchive)
+void cArchive::WriteInt32(int32_t i) // throw(eArchive)
 {
     i = tw_htonl(i);
-    WriteBlob(&i, sizeof(int32));
+    WriteBlob(&i, sizeof(int32_t));
 }
 
-void cArchive::WriteInt64(int64 i) // throw(eArchive)
+void cArchive::WriteInt64(int64_t i) // throw(eArchive)
 {
     i = tw_htonll(i);
-    WriteBlob(&i, sizeof(int64));
+    WriteBlob(&i, sizeof(int64_t));
 }
 
 // NOTE:BAM 10/11/99 -- we store unsigned size, but it really only works with
@@ -159,7 +159,7 @@ void cArchive::WriteInt64(int64 i) // throw(eArchive)
 // resize() in ReadString().
 // format for written string: 16-bit unsigned size, then a list of 16-bit UCS2 (Unicode) characters
 // not including terminating NULL
-void cArchive::WriteString(TSTRING s) // throw(eArchive)
+void cArchive::WriteString(const TSTRING& s) // throw(eArchive)
 {
     // convert string to a UCS2 string
     wc16_string ws;
@@ -170,7 +170,7 @@ void cArchive::WriteString(TSTRING s) // throw(eArchive)
     if (ws.length() > TSS_INT16_MAX)
         ThrowAndAssert(eArchiveStringTooLong());
 
-    WriteInt16(static_cast<int16>(ws.length()));
+    WriteInt16(static_cast<int16_t>(ws.length()));
 
     // write out each 16 bit character
     // RAD:09/03/99 -- Optimized for performance with "const"
@@ -186,9 +186,9 @@ void cArchive::WriteBlob(const void* pBlob, int count) // throw(eArchive)
         ThrowAndAssert(eArchiveWrite());
 }
 
-int32 cArchive::GetStorageSize(const TSTRING& str)
+int32_t cArchive::GetStorageSize(const TSTRING& str)
 {
-    int32 size = sizeof(int32); // the length is always stored
+    int32_t size = sizeof(int32_t); // the length is always stored
     //
     // after the length, all of the characters in the string are written as 16-bit values,
     // except for the null character
@@ -198,19 +198,19 @@ int32 cArchive::GetStorageSize(const TSTRING& str)
     return size;
 }
 
-int64 cArchive::Copy(cArchive* pFrom, int64 amt)
+int64_t cArchive::Copy(cArchive* pFrom, int64_t amt)
 {
     enum
     {
         BUF_SIZE = 2048
     };
-    int8  buf[BUF_SIZE];
-    int64 amtLeft = amt;
+    int8_t  buf[BUF_SIZE];
+    int64_t amtLeft = amt;
 
     while (amtLeft > 0)
     {
-        int64 amtToRead = amtLeft > (int64)BUF_SIZE ? (int64)BUF_SIZE : amtLeft;
-        int64 amtRead   = pFrom->ReadBlob(buf, static_cast<int>(amtToRead));
+        int64_t amtToRead = amtLeft > (int64_t)BUF_SIZE ? (int64_t)BUF_SIZE : amtLeft;
+        int64_t amtRead   = pFrom->ReadBlob(buf, static_cast<int>(amtToRead));
         amtLeft -= amtRead;
         WriteBlob(buf, static_cast<int>(amtRead));
         if (amtRead < amtToRead)
@@ -236,7 +236,7 @@ cMemMappedArchive::~cMemMappedArchive()
 {
 }
 
-int64 cMemMappedArchive::GetMappedOffset() const // throw(eArchive)
+int64_t cMemMappedArchive::GetMappedOffset() const // throw(eArchive)
 {
     if (mpMappedMem == 0)
         ThrowAndAssert(eArchiveMemmap());
@@ -244,7 +244,7 @@ int64 cMemMappedArchive::GetMappedOffset() const // throw(eArchive)
     return mMappedOffset;
 }
 
-int64 cMemMappedArchive::GetMappedLength() const // throw(eArchive)
+int64_t cMemMappedArchive::GetMappedLength() const // throw(eArchive)
 {
     if (mpMappedMem == 0)
         ThrowAndAssert(eArchiveMemmap());
@@ -268,7 +268,7 @@ void* cMemMappedArchive::GetMap() // throw(eArchive)
     return mpMappedMem;
 }
 
-void cMemMappedArchive::SetNewMap(void* pMap, int64 offset, int64 length) const
+void cMemMappedArchive::SetNewMap(void* pMap, int64_t offset, int64_t length) const
 {
     if (pMap == 0)
     {
@@ -310,7 +310,7 @@ bool cMemoryArchive::EndOfFile()
     return mReadHead >= mLogicalSize;
 }
 
-void cMemoryArchive::Seek(int64 offset, SeekFrom from) // throw(eArchive)
+void cMemoryArchive::Seek(int64_t offset, SeekFrom from) // throw(eArchive)
 {
     switch (from)
     {
@@ -334,12 +334,12 @@ void cMemoryArchive::Seek(int64 offset, SeekFrom from) // throw(eArchive)
     mReadHead = static_cast<int>(offset);
 }
 
-int64 cMemoryArchive::CurrentPos() const
+int64_t cMemoryArchive::CurrentPos() const
 {
     return mReadHead;
 }
 
-int64 cMemoryArchive::Length() const
+int64_t cMemoryArchive::Length() const
 {
     return mLogicalSize;
 }
@@ -352,7 +352,7 @@ void cMemoryArchive::Truncate()
     AllocateMemory(mLogicalSize);
 }
 
-void cMemoryArchive::MapArchive(int64 offset, int64 len) // throw(eArchive)
+void cMemoryArchive::MapArchive(int64_t offset, int64_t len) // throw(eArchive)
 {
     if (offset + (int)len > mLogicalSize)
         AllocateMemory(static_cast<int>(offset + len));
@@ -360,7 +360,7 @@ void cMemoryArchive::MapArchive(int64 offset, int64 len) // throw(eArchive)
     SetNewMap(mpMemory + offset, offset, len);
 }
 
-void cMemoryArchive::MapArchive(int64 offset, int64 len) const // throw(eArchive)
+void cMemoryArchive::MapArchive(int64_t offset, int64_t len) const // throw(eArchive)
 {
     if (offset + (int)len > mLogicalSize)
         ThrowAndAssert(eArchiveMemmap());
@@ -414,7 +414,7 @@ void cMemoryArchive::AllocateMemory(int len) // throw(eArchive)
         while (mAllocatedLen < len)
             mAllocatedLen *= 2;
 
-        int8* pNewMem = new int8[mAllocatedLen];
+        int8_t* pNewMem = new int8_t[mAllocatedLen];
         if (mpMemory != 0)
         {
             memcpy(pNewMem, mpMemory, mLogicalSize);
@@ -436,7 +436,7 @@ void cMemoryArchive::AllocateMemory(int len) // throw(eArchive)
         if (len < (mAllocatedLen >> 1) && mAllocatedLen > MIN_ALLOCATED_SIZE)
         {
             // shrink the buffer
-            int8* pNewMem = new int8[len];
+            int8_t* pNewMem = new int8_t[len];
             ASSERT(mpMemory);
             memcpy(pNewMem, mpMemory, len);
             delete [] mpMemory;
@@ -459,9 +459,9 @@ class cFixedMemArchive : public cBidirArchive
 {
 public:
 
-    int8*   mpMemory;
-    int32   mSize;
-    int32   mReadHead;
+    int8_t*  mpMemory;
+    int32_t   mSize;
+    int32_t   mReadHead;
 };
 */
 
@@ -472,7 +472,7 @@ cFixedMemArchive::cFixedMemArchive() : mpMemory(0), mSize(0), mReadHead(0)
 {
 }
 
-cFixedMemArchive::cFixedMemArchive(int8* pMem, int32 size) : mpMemory(0), mSize(0), mReadHead(0)
+cFixedMemArchive::cFixedMemArchive(int8_t* pMem, int32_t size) : mpMemory(0), mSize(0), mReadHead(0)
 {
     Attach(pMem, size);
 }
@@ -481,14 +481,14 @@ cFixedMemArchive::~cFixedMemArchive()
 {
 }
 
-void cFixedMemArchive::Attach(int8* pMem, int32 size)
+void cFixedMemArchive::Attach(int8_t* pMem, int32_t size)
 {
     mpMemory  = pMem;
     mSize     = size;
     mReadHead = 0;
 }
 
-void cFixedMemArchive::Seek(int64 offset, SeekFrom from) // throw(eArchive)
+void cFixedMemArchive::Seek(int64_t offset, SeekFrom from) // throw(eArchive)
 {
     switch (from)
     {
@@ -509,15 +509,15 @@ void cFixedMemArchive::Seek(int64 offset, SeekFrom from) // throw(eArchive)
         ThrowAndAssert(eArchiveSeek(TSS_GetString(cCore, core::STR_MEMARCHIVE_FILENAME),
                                     TSS_GetString(cCore, core::STR_MEMARCHIVE_ERRSTR)));
 
-    mReadHead = static_cast<int32>(offset);
+    mReadHead = static_cast<int32_t>(offset);
 }
 
-int64 cFixedMemArchive::CurrentPos() const
+int64_t cFixedMemArchive::CurrentPos() const
 {
     return mReadHead;
 }
 
-int64 cFixedMemArchive::Length() const
+int64_t cFixedMemArchive::Length() const
 {
     return mSize;
 }
@@ -583,7 +583,7 @@ bool cFileArchive::EndOfFile()
 // Seek -- This is where the actual offset is performed.  The default
 // for each archive will be 0.
 /////////////////////////////////////////////////////////////////////////
-void cFileArchive::Seek(int64 offset, SeekFrom from) // throw(eArchive)
+void cFileArchive::Seek(int64_t offset, SeekFrom from) // throw(eArchive)
 {
     try
     {
@@ -614,7 +614,7 @@ void cFileArchive::Seek(int64 offset, SeekFrom from) // throw(eArchive)
     }
 }
 
-int64 cFileArchive::CurrentPos(void) const
+int64_t cFileArchive::CurrentPos(void) const
 {
     return mReadHead;
 }
@@ -622,7 +622,7 @@ int64 cFileArchive::CurrentPos(void) const
 /////////////////////////////////////////////////////////////////////////
 // Length -- Returns the size of the current file archive.
 /////////////////////////////////////////////////////////////////////////
-int64 cFileArchive::Length(void) const
+int64_t cFileArchive::Length(void) const
 {
     try
     {
@@ -637,12 +637,12 @@ int64 cFileArchive::Length(void) const
 /////////////////////////////////////////////////////////////////////////
 // OpenRead -- Opens the file to be read only.
 /////////////////////////////////////////////////////////////////////////
-void cFileArchive::OpenRead(const TCHAR* filename, uint32 openFlags)
+void cFileArchive::OpenRead(const TCHAR* filename, uint32_t openFlags)
 {
     try
     {
         // set up open flags
-        uint32 flags = cFile::OPEN_READ;
+        uint32_t flags = cFile::OPEN_READ;
         flags |= ((openFlags & FA_OPEN_TRUNCATE) ? cFile::OPEN_TRUNCATE : 0);
         flags |= ((openFlags & FA_OPEN_TEXT)     ? cFile::OPEN_TEXT     : 0);
         flags |= ((openFlags & FA_SCANNING)      ? cFile::OPEN_SCANNING : 0);
@@ -665,12 +665,12 @@ void cFileArchive::OpenRead(const TCHAR* filename, uint32 openFlags)
 /////////////////////////////////////////////////////////////////////////
 // OpenReadWrite -- Opens the file to be read or written to
 /////////////////////////////////////////////////////////////////////////
-void cFileArchive::OpenReadWrite(const TCHAR* filename, uint32 openFlags)
+void cFileArchive::OpenReadWrite(const TCHAR* filename, uint32_t openFlags)
 {
     try
     {
         // set up open flags
-        uint32 flags = cFile::OPEN_WRITE;
+        uint32_t flags = cFile::OPEN_WRITE;
         flags |= ((openFlags & FA_OPEN_TRUNCATE) ? cFile::OPEN_TRUNCATE : 0);
         flags |= ((openFlags & FA_OPEN_TEXT)     ? cFile::OPEN_TEXT     : 0);
         flags |= ((openFlags & FA_SCANNING)      ? cFile::OPEN_SCANNING : 0);
@@ -743,10 +743,10 @@ int cFileArchive::Read(void* pDest, int count)
         else
         {
             int   i;
-            int32 dummy;
-            for (i = count;; i -= sizeof(int32))
+            int32_t dummy;
+            for (i = count;; i -= sizeof(int32_t))
             {
-                if (i < (int)sizeof(int32))
+                if (i < (int)sizeof(int32_t))
                 {
                     if (i > 0)
                         mCurrentFile.Read(&dummy, i);
@@ -773,7 +773,7 @@ int cFileArchive::Write(const void* pDest, int count) // throw(eArchive)
 {
     try
     {
-        int64 actual_count = 0;
+        int64_t actual_count = 0;
         ASSERT(mCurrentFile.isWritable);
 
         actual_count = mCurrentFile.Write(pDest, count);
@@ -834,7 +834,7 @@ void cFileArchive::Truncate() // throw(eArchive)
 //
 // since we'll never open an existing file, the truncateFile flag is unnecessary.
 /////////////////////////////////////////////////////////////////////////
-void cLockedTemporaryFileArchive::OpenReadWrite(const TCHAR* filename, uint32 openFlags)
+void cLockedTemporaryFileArchive::OpenReadWrite(const TCHAR* filename, uint32_t openFlags)
 {
     TSTRING strTempFile;
 
@@ -868,7 +868,7 @@ void cLockedTemporaryFileArchive::OpenReadWrite(const TCHAR* filename, uint32 op
         // create file
 
         // set up flags
-        uint32 flags = cFile::OPEN_WRITE | cFile::OPEN_LOCKED_TEMP | cFile::OPEN_CREATE | cFile::OPEN_EXCLUSIVE;
+        uint32_t flags = cFile::OPEN_WRITE | cFile::OPEN_LOCKED_TEMP | cFile::OPEN_CREATE | cFile::OPEN_EXCLUSIVE;
         if (openFlags & FA_OPEN_TRUNCATE)
             flags |= cFile::OPEN_TRUNCATE;
         if (openFlags & FA_OPEN_TEXT)

--- a/src/core/archive.h
+++ b/src/core/archive.h
@@ -103,24 +103,24 @@ public:
     // All write functions throw exceptions for unexpected events like
     // running out of memory or disk space.
     //
-    void ReadInt16(int16& ret);    // throw(eArchive)
-    void ReadInt32(int32& ret);    // throw(eArchive)
-    void ReadInt64(int64& ret);    // throw(eArchive)
+    void ReadInt16(int16_t& ret);    // throw(eArchive)
+    void ReadInt32(int32_t& ret);    // throw(eArchive)
+    void ReadInt64(int64_t& ret);    // throw(eArchive)
     void ReadString(TSTRING& ret); // throw(eArchive)
     int  ReadBlob(void* pBlob, int count);
-    void WriteInt16(int16 i);                     // throw(eArchive)
-    void WriteInt32(int32 i);                     // throw(eArchive)
-    void WriteInt64(int64 i);                     // throw(eArchive)
-    void WriteString(TSTRING s);                  // throw(eArchive)
+    void WriteInt16(int16_t i);                     // throw(eArchive)
+    void WriteInt32(int32_t i);                     // throw(eArchive)
+    void WriteInt64(int64_t i);                     // throw(eArchive)
+    void WriteString(const TSTRING& s);                  // throw(eArchive)
     void WriteBlob(const void* pBlob, int count); // throw(eArchive)
 
-    static int32 GetStorageSize(const TSTRING& str);
+    static int32_t GetStorageSize(const TSTRING& str);
     // this method calculates how many bytes the given string will take up in the archive and returns
     // that value
     // NOTE -- if the implementation of ReadString() or WriteString() ever changes, this method will also
     //          need to change.
 
-    int64 Copy(cArchive* pFrom, int64 amt); // throw(eArchive)
+    int64_t Copy(cArchive* pFrom, int64_t amt); // throw(eArchive)
         // this method copies amt bytes from pFrom to itself, throwing an eArchive if anything goes wrong.
 
     // only makes sense to call for reading archives
@@ -146,9 +146,9 @@ public:
         END       = -1
     };
 
-    virtual void  Seek(int64 offset, SeekFrom from) = 0; // throw(eArchive);
-    virtual int64 CurrentPos() const                = 0;
-    virtual int64 Length() const                    = 0;
+    virtual void  Seek(int64_t offset, SeekFrom from) = 0; // throw(eArchive);
+    virtual int64_t CurrentPos() const                = 0;
+    virtual int64_t Length() const                    = 0;
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -166,22 +166,22 @@ public:
     cMemMappedArchive();
     virtual ~cMemMappedArchive();
 
-    virtual void MapArchive(int64 offset, int64 len)       = 0; // throw(eArchive);
-    virtual void MapArchive(int64 offset, int64 len) const = 0; // throw(eArchive);
+    virtual void MapArchive(int64_t offset, int64_t len)       = 0; // throw(eArchive);
+    virtual void MapArchive(int64_t offset, int64_t len) const = 0; // throw(eArchive);
         // the const version of MapArchive() does not allow the archive to grow in size
 
-    int64       GetMappedOffset() const; // throw(eArchive)
-    int64       GetMappedLength() const; // throw(eArchive)
+    int64_t     GetMappedOffset() const; // throw(eArchive)
+    int64_t     GetMappedLength() const; // throw(eArchive)
     void*       GetMap();                // throw(eArchive)
     const void* GetMap() const;
 
 protected:
-    mutable void* mpMappedMem;
-    mutable int64 mMappedOffset;
-    mutable int64 mMappedLength;
+    mutable void*   mpMappedMem;
+    mutable int64_t mMappedOffset;
+    mutable int64_t mMappedLength;
 
     // call in derived class to set above vars
-    void SetNewMap(void* pMap, int64 offset, int64 length) const;
+    void SetNewMap(void* pMap, int64_t offset, int64_t length) const;
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -198,25 +198,25 @@ public:
     ~cMemoryArchive();
 
     virtual bool  EndOfFile();
-    virtual void  Seek(int64 offset, SeekFrom from); // throw(eArchive)
-    virtual int64 CurrentPos() const;
-    virtual int64 Length() const;
-    virtual void  MapArchive(int64 offset, int64 len);       // throw(eArchive)
-    virtual void  MapArchive(int64 offset, int64 len) const; // throw(eArchive)
+    virtual void  Seek(int64_t offset, SeekFrom from); // throw(eArchive)
+    virtual int64_t CurrentPos() const;
+    virtual int64_t Length() const;
+    virtual void  MapArchive(int64_t offset, int64_t len);       // throw(eArchive)
+    virtual void  MapArchive(int64_t offset, int64_t len) const; // throw(eArchive)
 
     void Truncate(); // set the length to the current pos
 
-    int8* GetMemory() const
+    int8_t* GetMemory() const
     {
         return mpMemory;
     }
 
 protected:
-    int8* mpMemory;
-    int   mAllocatedLen;
-    int   mMaxAllocatedLen;
-    int   mLogicalSize;
-    int   mReadHead;
+    int8_t* mpMemory;
+    int     mAllocatedLen;
+    int     mMaxAllocatedLen;
+    int     mLogicalSize;
+    int     mReadHead;
 
     virtual int  Read(void* pDest, int count);
     virtual int  Write(const void* pDest, int count); // throw(eArchive)
@@ -231,19 +231,19 @@ class cFixedMemArchive : public cBidirArchive
 {
 public:
     cFixedMemArchive();
-    cFixedMemArchive(int8* pMem, int32 size);
+    cFixedMemArchive(int8_t* pMem, int32_t size);
     virtual ~cFixedMemArchive();
 
-    void Attach(int8* pMem, int32 size);
+    void Attach(int8_t* pMem, int32_t size);
     // this method associates the archive with pMem and sets the size of the
     // archive. Unlike cMemoryArchive, this may never grow or shrink in size.
 
     //-----------------------------------
     // cBidirArchive interface
     //-----------------------------------
-    virtual void  Seek(int64 offset, SeekFrom from); // throw(eArchive);
-    virtual int64 CurrentPos() const;
-    virtual int64 Length() const;
+    virtual void  Seek(int64_t offset, SeekFrom from); // throw(eArchive);
+    virtual int64_t CurrentPos() const;
+    virtual int64_t Length() const;
     virtual bool  EndOfFile();
 
 protected:
@@ -253,9 +253,9 @@ protected:
     virtual int Read(void* pDest, int count);        // throw(eArchive)
     virtual int Write(const void* pDest, int count); // throw(eArchive)
 
-    int8* mpMemory;
-    int32 mSize;
-    int32 mReadHead;
+    int8_t* mpMemory;
+    int32_t mSize;
+    int32_t mReadHead;
 };
 
 class cFileArchive : public cBidirArchive
@@ -273,8 +273,8 @@ public:
     };
 
     // TODO: Open should throw
-    virtual void OpenRead(const TCHAR* filename, uint32 openFlags = 0);
-    virtual void OpenReadWrite(const TCHAR* filename, uint32 openFlags = FA_OPEN_TRUNCATE);
+    virtual void OpenRead(const TCHAR* filename, uint32_t openFlags = 0);
+    virtual void OpenReadWrite(const TCHAR* filename, uint32_t openFlags = FA_OPEN_TRUNCATE);
     // opens a file for reading or writing; the file is always created if it doesn't exist,
     // and is truncated to zero length if truncateFile is set to true;
     TSTRING      GetCurrentFilename(void) const;
@@ -285,14 +285,14 @@ public:
     // cBidirArchive interface
     //-----------------------------------
     virtual bool  EndOfFile();
-    virtual void  Seek(int64 offset, SeekFrom from); // throw(eArchive)
-    virtual int64 CurrentPos() const;
-    virtual int64 Length() const;
+    virtual void  Seek(int64_t offset, SeekFrom from); // throw(eArchive)
+    virtual int64_t CurrentPos() const;
+    virtual int64_t Length() const;
 
 
 protected:
-    int64 mFileSize; //Size of FileArchive
-    int64 mReadHead; //Current position of read/write head
+    int64_t mFileSize; //Size of FileArchive
+    int64_t mReadHead; //Current position of read/write head
     //-----------------------------------
     // cArchive interface
     //-----------------------------------
@@ -301,7 +301,7 @@ protected:
     bool        isWritable;
     cFile       mCurrentFile;
     TSTRING     mCurrentFilename; //current file
-    uint32      mOpenFlags;
+    uint32_t    mOpenFlags;
 };
 
 ///////////////////////////////////////////////////////////////
@@ -315,7 +315,7 @@ protected:
 class cLockedTemporaryFileArchive : public cFileArchive
 {
 public:
-    virtual void OpenReadWrite(const TCHAR* filename = NULL, uint32 openFlags = FA_OPEN_TRUNCATE);
+    virtual void OpenReadWrite(const TCHAR* filename = NULL, uint32_t openFlags = FA_OPEN_TRUNCATE);
     // creates the file.  filename must not exist on the file system.
     // if filename is NULL, the class will create and use a temporary file.
     // truncateFile has no meaning
@@ -328,7 +328,7 @@ public:
 private:
     // open for read only makes no sense if we're always creating the file,
     // so disallow read only file opens
-    virtual void OpenRead(const TCHAR*, uint32 openFlags = 0)
+    virtual void OpenRead(const TCHAR*, uint32_t openFlags = 0)
     {
         ASSERT(false);
         THROW_INTERNAL("archive.h");

--- a/src/core/codeconvert.cpp
+++ b/src/core/codeconvert.cpp
@@ -1433,7 +1433,7 @@ int cGoodEnoughConverterer::Convert(ntdbs_t pwz, size_t nCount, const_ntmbs_t pb
             }
             else
             {
-                *dat = (uint16)(unsigned char)*at;
+                *dat = (uint16_t)(unsigned char)*at;
             }
 
             dat++;

--- a/src/core/crc32.cpp
+++ b/src/core/crc32.cpp
@@ -84,7 +84,7 @@
 
 #define BUFSIZE 4096
 
-static uint32 crctab[] = {
+static uint32_t crctab[] = {
     0x0,
     0x04c11db7, 0x09823b6e, 0x0d4326d9, 0x130476dc, 0x17c56b6b,
     0x1a864db2, 0x1e475005, 0x2608edb8, 0x22c9f00f, 0x2f8ad6d6,
@@ -154,7 +154,7 @@ void crcInit( CRC_INFO& crcInfo )
     crcInfo.crc         = 0;
 }
 
-void crcUpdate( CRC_INFO& crcInfo, const uint8* pbData, int cbDataLen )
+void crcUpdate( CRC_INFO& crcInfo, const uint8_t* pbData, int cbDataLen )
 {    
     for( int i = 0; i < cbDataLen; i++, pbData++ )
     {
@@ -168,7 +168,7 @@ void crcFinit( CRC_INFO& crcInfo )
 {
     // include the length
     //
-    uint32 len = crcInfo.cbTotalLen;
+    uint32_t len = crcInfo.cbTotalLen;
     for(; len != 0; len >>= 8)
         COMPUTE( crcInfo.crc, len & 0xff );
     

--- a/src/core/crc32.h
+++ b/src/core/crc32.h
@@ -37,14 +37,14 @@ class cArchive;
 
 typedef struct 
 {
-    uint32 crc;
-    uint32 cbTotalLen;
+    uint32_t crc;
+    uint32_t cbTotalLen;
 }
 CRC_INFO;
  
 // must have 8-bit bytes
 void crcInit  ( CRC_INFO& crcInfo );
-void crcUpdate( CRC_INFO& crcInfo, const uint8* pbData, int cbDataLen );
+void crcUpdate( CRC_INFO& crcInfo, const uint8_t* pbData, int cbDataLen );
 void crcFinit ( CRC_INFO& crcInfo );
 
 

--- a/src/core/epoch.cpp
+++ b/src/core/epoch.cpp
@@ -51,7 +51,7 @@ bool CheckEpoch()
     time_struct.tm_mday = 1;
     time_struct.tm_mon  = 0;
     time_struct.tm_year = 138;
-    int64 endoftime     = cTimeUtil::DateToTime(&time_struct);
+    int64_t endoftime     = cTimeUtil::DateToTime(&time_struct);
 
     if (time(0) > endoftime)
     {

--- a/src/core/error.cpp
+++ b/src/core/error.cpp
@@ -39,11 +39,11 @@
 ///////////////////////////////////////////////////////////////////////////////
 // CalcHash
 ///////////////////////////////////////////////////////////////////////////////
-uint32 eError::CalcHash(const char* name)
+uint32_t eError::CalcHash(const char* name)
 {
     CRC_INFO crc;
     crcInit(crc);
-    crcUpdate(crc, (const uint8*)name, strlen(name));
+    crcUpdate(crc, (const uint8_t*)name, strlen(name));
     crcFinit(crc);
     return crc.crc;
 }

--- a/src/core/error.h
+++ b/src/core/error.h
@@ -45,7 +45,7 @@ public:
     //-------------------------------------------------------------------------
     // Construction and Assignment
     //-------------------------------------------------------------------------
-    eError(const TSTRING& msg, uint32 flags = 0);
+    eError(const TSTRING& msg, uint32_t flags = 0);
     explicit eError(const eError& rhs);
     explicit eError();
     void operator=(const eError& rhs);
@@ -58,7 +58,7 @@ public:
     //-------------------------------------------------------------------------
     // Data Access
     //-------------------------------------------------------------------------
-    virtual uint32 GetID() const = 0;
+    virtual uint32_t GetID() const = 0;
     // returns a system wide unique identifier for this exception. See the
     // macro below for the typical implementation of this method.
     // This is used to associate the error with a string description of the
@@ -73,7 +73,7 @@ public:
     // be displayed as the "Second" part of an error message, or the derived
     // class should override GetMsg() and return a string appropriate for display.
 
-    uint32 GetFlags() const;
+    uint32_t GetFlags() const;
     // Flags are defined below. Currently, these only have an impact on how errors are
     // displayed.
 
@@ -86,7 +86,7 @@ public:
         SUPRESS_THIRD_MSG = 0x00000002  // supresses the "continuing" or "exiting" message
     };
 
-    void SetFlags(uint32 flags);
+    void SetFlags(uint32_t flags);
 
     //-------------------------------------------------------------------------
     // Flag Convenience Methods
@@ -103,7 +103,7 @@ public:
     //-------------------------------------------------------------------------
     // Utility Methods
     //-------------------------------------------------------------------------
-    static uint32 CalcHash(const char* name);
+    static uint32_t CalcHash(const char* name);
     // calculates the CRC32 of the string passed in as name. This methods
     // asserts that name is non null. This is used to generate unique IDs
     // for errors.
@@ -112,8 +112,8 @@ public:
     // Private Implementation
     //-------------------------------------------------------------------------
 protected:
-    TSTRING mMsg;
-    uint32  mFlags;
+    TSTRING   mMsg;
+    uint32_t  mFlags;
 };
 
 //-----------------------------------------------------------------------------
@@ -137,7 +137,7 @@ protected:
     class except : public base                                             \
     {                                                                      \
     public:                                                                \
-        except(const TSTRING& msg, uint32 flags = 0) : base(msg, flags)    \
+        except(const TSTRING& msg, uint32_t flags = 0) : base(msg, flags)    \
         {                                                                  \
         }                                                                  \
         TSS_BEGIN_EXCEPTION_EXPLICIT except(const except& rhs) : base(rhs) \
@@ -147,7 +147,7 @@ protected:
         {                                                                  \
         }                                                                  \
                                                                            \
-        virtual uint32 GetID() const                                       \
+        virtual uint32_t GetID() const                                       \
         {                                                                  \
             return CalcHash(#except);                                      \
         }
@@ -169,7 +169,7 @@ protected:
         {                                         \
         }                                         \
                                                   \
-        virtual uint32 GetID() const              \
+        virtual uint32_t GetID() const              \
         {                                         \
             return CalcHash(#except);             \
         }
@@ -195,7 +195,7 @@ protected:
 ///////////////////////////////////////////////////////////////////////////////
 // eError
 ///////////////////////////////////////////////////////////////////////////////
-inline eError::eError(const TSTRING& msg, uint32 flags) : mMsg(msg), mFlags(flags)
+inline eError::eError(const TSTRING& msg, uint32_t flags) : mMsg(msg), mFlags(flags)
 {
 }
 
@@ -241,7 +241,7 @@ inline TSTRING eError::GetMsg() const
 ///////////////////////////////////////////////////////////////////////////////
 // GetFlags
 ///////////////////////////////////////////////////////////////////////////////
-inline uint32 eError::GetFlags() const
+inline uint32_t eError::GetFlags() const
 {
     return mFlags;
 }
@@ -249,7 +249,7 @@ inline uint32 eError::GetFlags() const
 ///////////////////////////////////////////////////////////////////////////////
 // SetFlags
 ///////////////////////////////////////////////////////////////////////////////
-inline void eError::SetFlags(uint32 flags)
+inline void eError::SetFlags(uint32_t flags)
 {
     mFlags = flags;
 }
@@ -260,9 +260,9 @@ inline void eError::SetFlags(uint32 flags)
 inline void eError::SetFatality(bool fatal)
 {
     if (fatal)
-        mFlags &= ~(uint32)NON_FATAL;
+        mFlags &= ~(uint32_t)NON_FATAL;
     else
-        mFlags |= (uint32)NON_FATAL;
+        mFlags |= (uint32_t)NON_FATAL;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -270,7 +270,7 @@ inline void eError::SetFatality(bool fatal)
 ///////////////////////////////////////////////////////////////////////////////
 inline bool eError::IsFatal() const
 {
-    return (mFlags & (uint32)NON_FATAL) == 0;
+    return (mFlags & (uint32_t)NON_FATAL) == 0;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -279,9 +279,9 @@ inline bool eError::IsFatal() const
 inline void eError::SetSupressThird(bool supressThird)
 {
     if (supressThird)
-        mFlags |= (uint32)SUPRESS_THIRD_MSG;
+        mFlags |= (uint32_t)SUPRESS_THIRD_MSG;
     else
-        mFlags &= ~(uint32)SUPRESS_THIRD_MSG;
+        mFlags &= ~(uint32_t)SUPRESS_THIRD_MSG;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -289,7 +289,7 @@ inline void eError::SetSupressThird(bool supressThird)
 ///////////////////////////////////////////////////////////////////////////////
 inline bool eError::SupressThird() const
 {
-    return (mFlags & (uint32)SUPRESS_THIRD_MSG) == 0;
+    return (mFlags & (uint32_t)SUPRESS_THIRD_MSG) == 0;
 }
 
 

--- a/src/core/errorbucketimpl.cpp
+++ b/src/core/errorbucketimpl.cpp
@@ -77,7 +77,7 @@ void cErrorReporter::PrintErrorMsg(const eError& error, const TSTRING& strExtra)
     if (errStr.empty())
     {
         TOSTRINGSTREAM strm;
-        ASSERT(sizeof(uint32) == sizeof(unsigned int)); // for cast on next line
+        ASSERT(sizeof(uint32_t) == sizeof(unsigned int)); // for cast on next line
         strm << _T("Unknown Error ID ") << (unsigned int)error.GetID();
         errStr = strm.str();
     }
@@ -189,7 +189,7 @@ void cErrorQueue::Clear()
     mList.clear();
 }
 
-int cErrorQueue::GetNumErrors() const
+cErrorQueue::ListType::size_type cErrorQueue::GetNumErrors() const
 {
     return mList.size();
 }
@@ -234,19 +234,19 @@ const ePoly& cErrorQueueIter::GetError() const
 ///////////////////////////////////////////////////////////////////////////////
 // Read
 ///////////////////////////////////////////////////////////////////////////////
-void cErrorQueue::Read(iSerializer* pSerializer, int32 version)
+void cErrorQueue::Read(iSerializer* pSerializer, int32_t version)
 {
     if (version > Version())
         ThrowAndAssert(eSerializerVersionMismatch(_T("ErrorQueue Read")));
 
-    int32 size;
+    int32_t size;
     mList.clear();
     pSerializer->ReadInt32(size);
     for (int i = 0; i < size; ++i)
     {
-        int32   errorNumber;
+        int32_t   errorNumber;
         TSTRING errorString;
-        int32   flags;
+        int32_t   flags;
 
         pSerializer->ReadInt32(errorNumber);
         pSerializer->ReadString(errorString);

--- a/src/core/errorbucketimpl.h
+++ b/src/core/errorbucketimpl.h
@@ -102,15 +102,17 @@ class cErrorQueue : public cErrorBucket, public iTypedSerializable
     friend class cErrorQueueIter;
 
 public:
+    typedef std::list<ePoly> ListType;
+    
     void Clear();
     // remove all errors from the queue
-    int GetNumErrors() const;
+    ListType::size_type GetNumErrors() const;
     // returns how many errors are in the queue
 
     //
     // iSerializable interface
     //
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 
     //
@@ -122,7 +124,6 @@ protected:
     virtual void HandleError(const eError& error);
 
 private:
-    typedef std::list<ePoly> ListType;
     ListType                 mList;
 
     DECLARE_TYPEDSERIALIZABLE()

--- a/src/core/errortable.h
+++ b/src/core/errortable.h
@@ -51,10 +51,10 @@ class eError;
 //-----------------------------------------------------------------------------
 // cErrorTable
 //-----------------------------------------------------------------------------
-class cErrorTable : public cMessages_<uint32, TCHAR>
+class cErrorTable : public cMessages_<uint32_t, TCHAR>
 {
 public:
-    typedef cMessages_<uint32, TCHAR> inherited;
+    typedef cMessages_<uint32_t, TCHAR> inherited;
 
     //
     // Convenience Methods

--- a/src/core/errorutil.h
+++ b/src/core/errorutil.h
@@ -58,7 +58,7 @@ public:
     //-------------------------------------------------------------------------
     // Construction and Assignment
     //-------------------------------------------------------------------------
-    ePoly(uint32 id, const TSTRING& msg, uint32 flags = 0);
+    ePoly(uint32_t id, const TSTRING& msg, uint32_t flags = 0);
     explicit ePoly(const eError& rhs);
     explicit ePoly();
     void operator=(const eError& rhs);
@@ -66,11 +66,11 @@ public:
     //-------------------------------------------------------------------------
     // ID manipulation
     //-------------------------------------------------------------------------
-    virtual uint32 GetID() const;
-    void           SetID(uint32 id);
+    virtual uint32_t GetID() const;
+    void             SetID(uint32_t id);
 
 private:
-    uint32 mID;
+    uint32_t mID;
 };
 
 //-----------------------------------------------------------------------------
@@ -122,7 +122,7 @@ public:
 ///////////////////////////////////////////////////////////////////////////////
 // ePoly
 ///////////////////////////////////////////////////////////////////////////////
-inline ePoly::ePoly(uint32 id, const TSTRING& msg, uint32 flags) : eError(msg, flags), mID(id)
+inline ePoly::ePoly(uint32_t id, const TSTRING& msg, uint32_t flags) : eError(msg, flags), mID(id)
 {
 }
 
@@ -154,7 +154,7 @@ inline void ePoly::operator=(const eError& rhs)
 ///////////////////////////////////////////////////////////////////////////////
 // GetID
 ///////////////////////////////////////////////////////////////////////////////
-inline uint32 ePoly::GetID() const
+inline uint32_t ePoly::GetID() const
 {
     return mID;
 }
@@ -162,7 +162,7 @@ inline uint32 ePoly::GetID() const
 ///////////////////////////////////////////////////////////////////////////////
 // SetID
 ///////////////////////////////////////////////////////////////////////////////
-inline void ePoly::SetID(uint32 id)
+inline void ePoly::SetID(uint32_t id)
 {
     mID = id;
 }

--- a/src/core/file.h
+++ b/src/core/file.h
@@ -106,7 +106,7 @@ public:
     /************ User Interface **************************/
 
     // Both Open methods ALWAYS open files in BINARY mode!
-    void Open(const TSTRING& sFileName, uint32 flags = OPEN_READ); //throw(eFile)
+    void Open(const TSTRING& sFileName, uint32_t flags = OPEN_READ); //throw(eFile)
     void Close(void);                                              //throw(eFile)
     bool IsOpen(void) const;
 

--- a/src/core/file_unix.cpp
+++ b/src/core/file_unix.cpp
@@ -78,7 +78,7 @@ struct cFile_i
     int     m_fd;         //underlying file descriptor
     FILE*   mpCurrStream; //currently defined file stream
     TSTRING mFileName;    //the name of the file we are currently referencing.
-    uint32  mFlags;       //Flags used to open the file
+    uint32_t  mFlags;       //Flags used to open the file
 };
 
 //Ctor
@@ -132,10 +132,10 @@ cFile::~cFile()
 ///////////////////////////////////////////////////////////////////////////////
 
 #if !USES_DEVICE_PATH
-void cFile::Open(const TSTRING& sFileName, uint32 flags)
+void cFile::Open(const TSTRING& sFileName, uint32_t flags)
 {
 #else
-void cFile::Open(const TSTRING& sFileNameC, uint32 flags)
+void cFile::Open(const TSTRING& sFileNameC, uint32_t flags)
 {
     TSTRING sFileName = cDevicePath::AsNative(sFileNameC);
 #endif

--- a/src/core/fileerror.cpp
+++ b/src/core/fileerror.cpp
@@ -37,7 +37,7 @@
 #include "corestrings.h"
 
 // TODO: Make this use MakeFileError() for consistency
-eFileError::eFileError(const TSTRING& filename, const TSTRING& description, uint32 flags) : eError(_T(""), flags)
+eFileError::eFileError(const TSTRING& filename, const TSTRING& description, uint32_t flags) : eError(_T(""), flags)
 {
     mFilename = filename;
     mMsg      = description;

--- a/src/core/fileerror.h
+++ b/src/core/fileerror.h
@@ -56,13 +56,13 @@ private:
 TSTRING mFilename;
 
 public:
-eFileError(const TSTRING& filename, const TSTRING& description, uint32 flags = 0);
+eFileError(const TSTRING& filename, const TSTRING& description, uint32_t flags = 0);
 
 explicit eFileError(const eFileError& rhs) : eError(rhs)
 {
     mFilename = rhs.mFilename;
 }
-eFileError(const TSTRING& msg, uint32 flags = 0) : eError(msg, flags)
+eFileError(const TSTRING& msg, uint32_t flags = 0) : eError(msg, flags)
 {
 }
 
@@ -75,7 +75,7 @@ TSS_END_EXCEPTION()
 
 #    define TSS_FILE_EXCEPTION(except, base)                                                               \
         TSS_BEGIN_EXCEPTION(except, base)                                                                  \
-        except(const TSTRING& filename, const TSTRING& msg, uint32 flags = 0) : base(filename, msg, flags) \
+        except(const TSTRING& filename, const TSTRING& msg, uint32_t flags = 0) : base(filename, msg, flags) \
         {                                                                                                  \
         }                                                                                                  \
         TSS_END_EXCEPTION()

--- a/src/core/fileheader.cpp
+++ b/src/core/fileheader.cpp
@@ -41,7 +41,7 @@
 // I changed this magic number in 2.1 since we now support versioning in the file header.
 // (the old magic number was 0x00202039)
 // I generated the random number using the random.org web site.
-const uint32 FILE_HEADER_MAGIC_NUMBER = 0x78f9beb3;
+const uint32_t FILE_HEADER_MAGIC_NUMBER = 0x78f9beb3;
 
 ///////////////////////////////////////////////////////////////////////////////
 // class cFileHeaderID
@@ -66,7 +66,7 @@ void cFileHeaderID::operator=(const TCHAR* pszId)
     if (!(N < cFileHeaderID::MAXBYTES))
         throw eCharacter(TSS_GetString(cCore, core::STR_ERR_OVERFLOW));
 
-    mIDLen = static_cast<int16>(N); // know len is less than MAXBYTES
+    mIDLen = static_cast<int16_t>(N); // know len is less than MAXBYTES
     ::memcpy(mID, pszId, N * sizeof(char));
 }
 
@@ -82,9 +82,9 @@ int cFileHeaderID::operator==(const cFileHeaderID& rhs) const
     return (mIDLen == rhs.mIDLen) && (::memcmp(mID, rhs.mID, mIDLen * sizeof(char)) == 0);
 }
 
-void cFileHeaderID::Read(iSerializer* pSerializer, int32 /*version*/) // throw (eSerializer, eArchive)
+void cFileHeaderID::Read(iSerializer* pSerializer, int32_t /*version*/) // throw (eSerializer, eArchive)
 {
-    int16 len;
+    int16_t len;
     pSerializer->ReadInt16(len);
     if ((len < 0) || (len >= cFileHeaderID::MAXBYTES))
     {
@@ -139,7 +139,7 @@ void cFileHeader::SetID(const cFileHeaderID& id)
     mID = id;
 }
 
-void cFileHeader::SetVersion(uint32 v)
+void cFileHeader::SetVersion(uint32_t v)
 {
     mVersion = v;
 }
@@ -149,12 +149,12 @@ void cFileHeader::SetEncoding(Encoding e)
     mEncoding = e;
 }
 
-void cFileHeader::Read(iSerializer* pSerializer, int32 /*version*/) // throw (eSerializer, eArchive)
+void cFileHeader::Read(iSerializer* pSerializer, int32_t /*version*/) // throw (eSerializer, eArchive)
 {
-    int16 e;
-    int32 len;
-    int32 magicNumber;
-    int32 version;
+    int16_t e;
+    int32_t len;
+    int32_t magicNumber;
+    int32_t version;
 
     cDebug d("cFileHeader::Read");
 
@@ -224,9 +224,9 @@ void cFileHeader::Write(iSerializer* pSerializer) const // throw (eSerializer, e
 
     pSerializer->WriteInt32(mVersion);
 
-    pSerializer->WriteInt16(static_cast<int16>(mEncoding));
+    pSerializer->WriteInt16(static_cast<int16_t>(mEncoding));
 
-    int32 len = static_cast<int32>(mBaggage.Length());
+    int32_t len = static_cast<int32_t>(mBaggage.Length());
 
     ASSERT(len >= 0);
     ASSERT(len <= 0xFFFF);

--- a/src/core/fileheader.h
+++ b/src/core/fileheader.h
@@ -59,7 +59,7 @@ public:
     int  operator==(const cFileHeaderID& rhs) const;
     int  operator!=(const cFileHeaderID& rhs) const;
 
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 
 private:
@@ -68,7 +68,7 @@ private:
     // the way we implemented cFCONames.
     // Note: We store the string as narrow chars, since
     // the program is the only person who will see them.
-    int16 mIDLen;
+    int16_t mIDLen;
 
     enum
     {
@@ -119,8 +119,8 @@ public:
     void                 SetID(const cFileHeaderID& id);
     const cFileHeaderID& GetID() const;
 
-    void   SetVersion(uint32 v);
-    uint32 GetVersion() const;
+    void     SetVersion(uint32_t v);
+    uint32_t GetVersion() const;
 
     void     SetEncoding(Encoding e);
     Encoding GetEncoding() const;
@@ -128,12 +128,12 @@ public:
     cMemoryArchive&       GetBaggage();
     const cMemoryArchive& GetBaggage() const;
 
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
-    virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
+    virtual void Write(iSerializer* pSerializer) const;               // throw (eSerializer, eArchive)
 
 protected:
     cFileHeaderID  mID;
-    uint32         mVersion;
+    uint32_t       mVersion;
     Encoding       mEncoding;
     cMemoryArchive mBaggage; // items that have been serialized to this object
 };
@@ -143,7 +143,7 @@ inline const cFileHeaderID& cFileHeader::GetID() const
     return mID;
 }
 
-inline uint32 cFileHeader::GetVersion() const
+inline uint32_t cFileHeader::GetVersion() const
 {
     return mVersion;
 }

--- a/src/core/fsservices.h
+++ b/src/core/fsservices.h
@@ -98,8 +98,8 @@
 // TYPEDEFS
 //=========================================================================
 
-typedef int64 cFSTime;
-typedef int64 cFSType;
+typedef int64_t cFSTime;
+typedef int64_t cFSType;
 
 //=========================================================================
 // GLOBALS
@@ -117,7 +117,7 @@ typedef int64 cFSType;
 //     it is the union of MAX(elem) for all the file systems that we support
 /*class cACLElem {
    // TODO this is just a place holder
-   // uint32   mUid;
+   // uint32_t   mUid;
 };*/
 
 // this class is used only to pass arguments to iFSServices
@@ -140,23 +140,23 @@ struct cFSStatArgs
     };
 
     // attr is fs dependent?
-    uint64  dev;     // dep
-    int64   ino;     // dep
-    int64   mode;    // dep
-    int64   nlink;   // indep
-    int64   uid;     // dep
-    int64   gid;     // dep
-    uint64  rdev;    // dep
-    int64   size;    // indep
-    cFSTime atime;   // indep
-    cFSTime mtime;   // indep
-    cFSTime ctime;   // indep
-    int64   blksize; // indep
-    int64   blocks;  // dep
-    int64   fstype;  // dep
-    TSTRING usid;    // dep
-    TSTRING gsid;    // dep
-                     // int64 mFileType;     // Matt's addition...
+    uint64_t  dev;     // dep
+    int64_t   ino;     // dep
+    int64_t   mode;    // dep
+    int64_t   nlink;   // indep
+    int64_t   uid;     // dep
+    int64_t   gid;     // dep
+    uint64_t  rdev;    // dep
+    int64_t   size;    // indep
+    cFSTime   atime;   // indep
+    cFSTime   mtime;   // indep
+    cFSTime   ctime;   // indep
+    int64_t   blksize; // indep
+    int64_t   blocks;  // dep
+    int64_t   fstype;  // dep
+    TSTRING   usid;    // dep
+    TSTRING   gsid;    // dep
+                     // int64_t mFileType;     // Matt's addition...
 
     FileType mFileType; // redundant with other information in this struct, but
                         // broken out for convenience
@@ -269,7 +269,7 @@ public:
 
     virtual bool GetCurrentUserName(TSTRING& tstrName) const = 0;
 
-    virtual bool GetIPAddress(uint32& uiIPAddress) = 0;
+    virtual bool GetIPAddress(uint32_t& uiIPAddress) = 0;
 
 
     ////////////////////////////////////////
@@ -305,8 +305,8 @@ public:
     ////////////////////////////////////////
     // miscellaneous utility functions
     ////////////////////////////////////////
-    virtual void ConvertModeToString(uint64 perm, TSTRING& tstrPerm) const = 0;
-    // takes a int64 permission (from stat) and changes it to look like UNIX's 'ls -l' (e.g. drwxrwxrwx)
+    virtual void ConvertModeToString(uint64_t perm, TSTRING& tstrPerm) const = 0;
+    // takes a int64_t permission (from stat) and changes it to look like UNIX's 'ls -l' (e.g. drwxrwxrwx)
     virtual bool FullPath(TSTRING& fullPath, const TSTRING& relPath, const TSTRING& pathRelFrom = _T("")) const = 0;
     // converts relPath into a fully qualified path, storing it in FullPath. If this
     // fails, false is returned.  if the path to which relPath is relative is not CWD, put it in pathRelFrom.

--- a/src/core/growheap.cpp
+++ b/src/core/growheap.cpp
@@ -45,9 +45,9 @@ public:
     {
     public:
         size_t mSize;
-        int8*  mpData;
+        int8_t*  mpData;
 
-        cHeap(size_t size) : mSize(size), mpData(new int8[size])
+        cHeap(size_t size) : mSize(size), mpData(new int8_t[size])
         {
             ASSERT(mpData != 0);
         }
@@ -118,7 +118,7 @@ void* cGrowHeap_i::Malloc(size_t size)
         // we have room to add this to the current heap.
         //
         ASSERT(mHeaps.back().mpData);
-        int8* ret = mHeaps.back().mpData + mCurOff;
+        int8_t* ret = mHeaps.back().mpData + mCurOff;
         mCurOff += size;
 
         return ret;

--- a/src/core/hashtable.h
+++ b/src/core/hashtable.h
@@ -172,9 +172,9 @@ public:
     bool Clear(void);
     //Clears the entire table and sets all node pointers to NULL
     bool   IsEmpty(void) const;
-    uint32 Hash(const KEY_TYPE& key) const;
+    uint32_t Hash(const KEY_TYPE& key) const;
     //The hashing function, taken from old Tripwire
-    int32 GetNumValues() const
+    int32_t GetNumValues() const
     {
         return mValuesInTable;
     };
@@ -189,9 +189,9 @@ private:
     cHashTable(const cHashTable& rhs);     // not impl
     void operator=(const cHashTable& rhs); // not impl
 
-    node** mTable;
-    int    mTableSize;
-    int32  mValuesInTable;
+    node**   mTable;
+    int      mTableSize;
+    int32_t  mValuesInTable;
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -506,12 +506,12 @@ bool cHashTable<KEY_TYPE, VAL_TYPE, COMPARE_OP, CONVERTER>::IsEmpty(void) const
 // Hash -- performs hashing on key, returns an integer index val.
 ////////////////////////////////////////////////////////////////////////////////
 template<class KEY_TYPE, class VAL_TYPE, class COMPARE_OP, class CONVERTER>
-uint32 cHashTable<KEY_TYPE, VAL_TYPE, COMPARE_OP, CONVERTER>::Hash(const KEY_TYPE& key) const
+uint32_t cHashTable<KEY_TYPE, VAL_TYPE, COMPARE_OP, CONVERTER>::Hash(const KEY_TYPE& key) const
 {
     CONVERTER   converter;
     int         len;
     const uint8_t* pb = converter(key, &len); //locates key
-    uint32      hindex;
+    uint32_t    hindex;
 
     hindex = *pb;
     while (len-- > 0)

--- a/src/core/haval.cpp
+++ b/src/core/haval.cpp
@@ -99,17 +99,17 @@
 #define P_(s) ()
 #endif
 
-void haval_string P_((char *, uint8 *)); /* hash a string */
-int  haval_file P_((char *, uint8 *));   /* hash a file */
+void haval_string P_((char *, uint8_t *)); /* hash a string */
+int  haval_file P_((char *, uint8_t *));   /* hash a file */
 void haval_stdin P_((void));                     /* hash input from stdin */
 void haval_start P_((haval_state *));            /* initialization */
 void haval_hash P_((haval_state *,
-        uint8 *, int));      /* updating routine */
-void haval_end P_((haval_state *, uint8 *)); /* finalization */
+        uint8_t *, int));      /* updating routine */
+void haval_end P_((haval_state *, uint8_t *)); /* finalization */
 void haval_hash_block P_((haval_state *));       /* hash a 32-word block */
 static void haval_tailor P_((haval_state *));    /* folding the last output */
 
-static uint8 padding[128] = {        /* constants for padding */
+static uint8_t padding[128] = {        /* constants for padding */
 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -251,7 +251,7 @@ static uint8 padding[128] = {        /* constants for padding */
  * assume the number of characters is a multiple of four.
  */
 #define ch2uint(string, word, slen) {      \
-  uint8 *sp = string;              \
+  uint8_t *sp = string;              \
   haval_word    *wp = word;                \
   while (sp < (string) + (slen)) {         \
     *wp++ =  (haval_word)*sp            |  \
@@ -265,12 +265,12 @@ static uint8 padding[128] = {        /* constants for padding */
 /* translate each word into four characters */
 #define uint2ch(word, string, wlen) {              \
   haval_word    *wp = word;                        \
-  uint8 *sp = string;                      \
+  uint8_t *sp = string;                      \
   while (wp < (word) + (wlen)) {                   \
-    *(sp++) = (uint8)( *wp        & 0xFF); \
-    *(sp++) = (uint8)((*wp >>  8) & 0xFF); \
-    *(sp++) = (uint8)((*wp >> 16) & 0xFF); \
-    *(sp++) = (uint8)((*wp >> 24) & 0xFF); \
+    *(sp++) = (uint8_t)( *wp        & 0xFF); \
+    *(sp++) = (uint8_t)((*wp >>  8) & 0xFF); \
+    *(sp++) = (uint8_t)((*wp >> 16) & 0xFF); \
+    *(sp++) = (uint8_t)((*wp >> 24) & 0xFF); \
     wp++;                                          \
   }                                                \
 }
@@ -278,23 +278,23 @@ static uint8 padding[128] = {        /* constants for padding */
 #if 0 //unused in OST
 
 /* hash a string */
-void haval_string (char *string, uint8 fingerprint[FPTLEN >> 3])
+void haval_string (char *string, uint8_t fingerprint[FPTLEN >> 3])
 {
   haval_state   state;
   unsigned int  len = strlen (string);
 
   haval_start (&state);
-  haval_hash (&state, (uint8 *)string, len);
+  haval_hash (&state, (uint8_t *)string, len);
   haval_end (&state, fingerprint);
 }
 
 /* hash a file */
-int haval_file (char* file_name, uint8 fingerprint[FPTLEN >> 3])
+int haval_file (char* file_name, uint8_t fingerprint[FPTLEN >> 3])
 {
     FILE          *file;
     haval_state   state;
     int           len;
-    uint8 buffer[1024];
+    uint8_t buffer[1024];
 
     if ((file = fopen (file_name, "rb")) == NULL)
     {
@@ -318,7 +318,7 @@ void haval_stdin ()
 {
   haval_state   state;
   int           i, len;
-  uint8 buffer[32],
+  uint8_t buffer[32],
                 fingerprint[FPTLEN >> 3];
 
   haval_start (&state);
@@ -351,7 +351,7 @@ void haval_start (haval_state *state)
  * hash a string of specified length.
  * to be used in conjunction with haval_start and haval_end.
  */
-void haval_hash (haval_state* state, uint8* str, int str_len)
+void haval_hash (haval_state* state, uint8_t* str, int str_len)
 {
   ASSERT(str_len >= 0);
 
@@ -374,17 +374,17 @@ void haval_hash (haval_state* state, uint8* str, int str_len)
 
   /* hash as many blocks as possible */
   if (rmd_len + str_len >= 128) {
-    memcpy (((uint8 *)state->block)+rmd_len, str, fill_len);
+    memcpy (((uint8_t *)state->block)+rmd_len, str, fill_len);
     haval_hash_block (state);
     for (i = fill_len; i + 127 < str_len; i += 128){
-      memcpy ((uint8 *)state->block, str+i, 128);
+      memcpy ((uint8_t *)state->block, str+i, 128);
       haval_hash_block (state);
     }
     rmd_len = 0;
   } else {
     i = 0;
   }
-  memcpy (((uint8 *)state->block)+rmd_len, str+i, str_len-i);
+  memcpy (((uint8_t *)state->block)+rmd_len, str+i, str_len-i);
 
 #else
 
@@ -409,19 +409,19 @@ void haval_hash (haval_state* state, uint8* str, int str_len)
 }
 
 /* finalization */
-void haval_end (haval_state* state, uint8 final_fpt[FPTLEN >> 3])
+void haval_end (haval_state* state, uint8_t final_fpt[FPTLEN >> 3])
 {
-  uint8 tail[10];
+  uint8_t tail[10];
   unsigned int  rmd_len, pad_len;
 
   /*
    * save the version number, the number of passes, the fingerprint 
    * length and the number of bits in the unpadded message.
    */
-  tail[0] = (uint8)(((FPTLEN  & 0x3) << 6) |
+  tail[0] = (uint8_t)(((FPTLEN  & 0x3) << 6) |
                             ((PASS    & 0x7) << 3) |
                              (HAVAL_VERSION & 0x7));
-  tail[1] = (uint8)((FPTLEN >> 2) & 0xFF);
+  tail[1] = (uint8_t)((FPTLEN >> 2) & 0xFF);
   uint2ch (state->count, &tail[2], 2);
 
   /* pad out to 118 mod 128 */

--- a/src/core/haval.h
+++ b/src/core/haval.h
@@ -98,13 +98,13 @@
 #include "core/tchar.h"
 #endif
 
-typedef uint32 haval_word; /* a HAVAL word = 32 bits */
+typedef uint32_t haval_word; /* a HAVAL word = 32 bits */
 
 typedef struct {
   haval_word    count[2];                /* number of bits in a message */
   haval_word    fingerprint[8];          /* current state of fingerprint */    
   haval_word    block[32];               /* buffer for a 32-word block */ 
-  uint8         remainder[32*4];         /* unhashed chars (No.<128) */   
+  uint8_t         remainder[32*4];         /* unhashed chars (No.<128) */
 } haval_state;
 
 /* Do not remove this line.  Protyping depends on it! 
@@ -118,14 +118,14 @@ typedef struct {
 #define P_(s) s
 //Old prototyping stuff... I will ignore it for now.
 #if 0 //unused in OST
-void haval_string P_((char *, uint8 *)); /* hash a string */
-int  haval_file P_((char *, uint8 *));   /* hash a file */
+void haval_string P_((char *, uint8_t *)); /* hash a string */
+int  haval_file P_((char *, uint8_t *));   /* hash a file */
 void haval_stdin P_((void));                     /* filter -- hash input from stdin */
 #endif
 
 void haval_start P_((haval_state *));            /* initialization */
-void haval_hash P_((haval_state* state, uint8* str, int str_len));
-void haval_end P_((haval_state *, uint8 *)); /* finalization */
+void haval_hash P_((haval_state* state, uint8_t* str, int str_len));
+void haval_end P_((haval_state *, uint8_t *)); /* finalization */
 void haval_hash_block P_((haval_state *));       /* hash a 32-word block */
 
 #endif //__HAVAL_H

--- a/src/core/haval.h
+++ b/src/core/haval.h
@@ -104,7 +104,7 @@ typedef struct {
   haval_word    count[2];                /* number of bits in a message */
   haval_word    fingerprint[8];          /* current state of fingerprint */    
   haval_word    block[32];               /* buffer for a 32-word block */ 
-  uint8_t         remainder[32*4];         /* unhashed chars (No.<128) */
+  uint8_t       remainder[32*4];         /* unhashed chars (No.<128) */
 } haval_state;
 
 /* Do not remove this line.  Protyping depends on it! 

--- a/src/core/md5.cpp
+++ b/src/core/md5.cpp
@@ -56,9 +56,9 @@
 #include "md5.h"
 
 /* forward declaration */
-static void Transform (uint32*, uint32*);
+static void Transform (uint32_t*, uint32_t*);
 
-static uint8 PADDING[64] = {
+static uint8_t PADDING[64] = {
   0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -85,22 +85,22 @@ static uint8 PADDING[64] = {
 /* FF, GG, HH, and II transformations for rounds 1, 2, 3, and 4 */
 /* Rotation is separate from addition to prevent recomputation */
 #define FF(a, b, c, d, x, s, ac) \
-  {(a) += F ((b), (c), (d)) + (x) + (uint32)(ac); \
+  {(a) += F ((b), (c), (d)) + (x) + (uint32_t)(ac); \
    (a) = ROTATE_LEFT ((a), (s)); \
    (a) += (b); \
   }
 #define GG(a, b, c, d, x, s, ac) \
-  {(a) += G ((b), (c), (d)) + (x) + (uint32)(ac); \
+  {(a) += G ((b), (c), (d)) + (x) + (uint32_t)(ac); \
    (a) = ROTATE_LEFT ((a), (s)); \
    (a) += (b); \
   }
 #define HH(a, b, c, d, x, s, ac) \
-  {(a) += H ((b), (c), (d)) + (x) + (uint32)(ac); \
+  {(a) += H ((b), (c), (d)) + (x) + (uint32_t)(ac); \
    (a) = ROTATE_LEFT ((a), (s)); \
    (a) += (b); \
   }
 #define II(a, b, c, d, x, s, ac) \
-  {(a) += I ((b), (c), (d)) + (x) + (uint32)(ac); \
+  {(a) += I ((b), (c), (d)) + (x) + (uint32_t)(ac); \
    (a) = ROTATE_LEFT ((a), (s)); \
    (a) += (b); \
   }
@@ -109,22 +109,22 @@ static uint8 PADDING[64] = {
    mdContext. All fields are set to zero.  */
 void MD5Init (MD5_CTX* mdContext)
 {
-  mdContext->i[0] = mdContext->i[1] = (uint32)0;
+  mdContext->i[0] = mdContext->i[1] = (uint32_t)0;
 
   /* Load magic initialization constants.
    */
-  mdContext->buf[0] = (uint32)0x67452301;
-  mdContext->buf[1] = (uint32)0xefcdab89;
-  mdContext->buf[2] = (uint32)0x98badcfe;
-  mdContext->buf[3] = (uint32)0x10325476;
+  mdContext->buf[0] = (uint32_t)0x67452301;
+  mdContext->buf[1] = (uint32_t)0xefcdab89;
+  mdContext->buf[2] = (uint32_t)0x98badcfe;
+  mdContext->buf[3] = (uint32_t)0x10325476;
 }
 
 /* The routine MD5Update updates the message-digest context to
    account for the presence of each of the characters inBuf[0..inLen-1]
    in the message whose digest is being computed.  */
-void MD5Update (MD5_CTX* mdContext, uint8* inBuf, unsigned int inLen)
+void MD5Update (MD5_CTX* mdContext, uint8_t* inBuf, unsigned int inLen)
 {
-  uint32 in[16];
+  uint32_t in[16];
   int mdi;
   unsigned int i, ii;
 
@@ -133,15 +133,15 @@ void MD5Update (MD5_CTX* mdContext, uint8* inBuf, unsigned int inLen)
 
   /* update number of bits */
 #ifndef UNICOS
-  if ((mdContext->i[0] + ((uint32)inLen << 3)) < mdContext->i[0])
+  if ((mdContext->i[0] + ((uint32_t)inLen << 3)) < mdContext->i[0])
 #else
-  if (((mdContext->i[0]+((uint32)inLen << 3)) & 0xffffffff) < mdContext->i[0])
+  if (((mdContext->i[0]+((uint32_t)inLen << 3)) & 0xffffffff) < mdContext->i[0])
 #endif
 
     mdContext->i[1]++;
 
-  mdContext->i[0] += ((uint32)inLen << 3);
-  mdContext->i[1] += ((uint32)inLen >> 29);
+  mdContext->i[0] += ((uint32_t)inLen << 3);
+  mdContext->i[1] += ((uint32_t)inLen >> 29);
 
   while (inLen--) {
     /* add new character to buffer, increment mdi */
@@ -150,10 +150,10 @@ void MD5Update (MD5_CTX* mdContext, uint8* inBuf, unsigned int inLen)
     /* transform if necessary */
     if (mdi == 0x40) {
       for (i = 0, ii = 0; i < 16; i++, ii += 4)
-        in[i] = (((uint32)mdContext->in[ii+3]) << 24) |
-                (((uint32)mdContext->in[ii+2]) << 16) |
-                (((uint32)mdContext->in[ii+1]) << 8) |
-                ((uint32)mdContext->in[ii]);
+        in[i] = (((uint32_t)mdContext->in[ii+3]) << 24) |
+                (((uint32_t)mdContext->in[ii+2]) << 16) |
+                (((uint32_t)mdContext->in[ii+1]) << 8) |
+                ((uint32_t)mdContext->in[ii]);
       Transform (mdContext->buf, in);
       mdi = 0;
     }
@@ -164,7 +164,7 @@ void MD5Update (MD5_CTX* mdContext, uint8* inBuf, unsigned int inLen)
    ends with the desired message digest in mdContext->digest[0...15].  */
 void MD5Final (MD5_CTX* mdContext)
 {
-  uint32 in[16];
+  uint32_t in[16];
   int mdi;
   unsigned int i, ii;
   unsigned int padLen;
@@ -182,28 +182,28 @@ void MD5Final (MD5_CTX* mdContext)
 
   /* append length in bits and transform */
   for (i = 0, ii = 0; i < 14; i++, ii += 4)
-    in[i] = (((uint32)mdContext->in[ii+3]) << 24) |
-            (((uint32)mdContext->in[ii+2]) << 16) |
-            (((uint32)mdContext->in[ii+1]) << 8) |
-            ((uint32)mdContext->in[ii]);
+    in[i] = (((uint32_t)mdContext->in[ii+3]) << 24) |
+            (((uint32_t)mdContext->in[ii+2]) << 16) |
+            (((uint32_t)mdContext->in[ii+1]) << 8) |
+            ((uint32_t)mdContext->in[ii]);
   Transform (mdContext->buf, in);
 
   /* store buffer in digest */
   for (i = 0, ii = 0; i < 4; i++, ii += 4) {
-    mdContext->digest[ii] = (uint8)(mdContext->buf[i] & 0xFF);
+    mdContext->digest[ii] = (uint8_t)(mdContext->buf[i] & 0xFF);
     mdContext->digest[ii+1] =
-      (uint8)((mdContext->buf[i] >> 8) & 0xFF);
+      (uint8_t)((mdContext->buf[i] >> 8) & 0xFF);
     mdContext->digest[ii+2] =
-      (uint8)((mdContext->buf[i] >> 16) & 0xFF);
+      (uint8_t)((mdContext->buf[i] >> 16) & 0xFF);
     mdContext->digest[ii+3] =
-      (uint8)((mdContext->buf[i] >> 24) & 0xFF);
+      (uint8_t)((mdContext->buf[i] >> 24) & 0xFF);
   }
 }
 
 /* Basic MD5 step. Transforms buf based on in.  */
-static void Transform (uint32* buf, uint32* in)
+static void Transform (uint32_t* buf, uint32_t* in)
 {
-  uint32 a = buf[0], b = buf[1], c = buf[2], d = buf[3];
+  uint32_t a = buf[0], b = buf[1], c = buf[2], d = buf[3];
 
   /* Round 1 */
 #define S11 7

--- a/src/core/md5.h
+++ b/src/core/md5.h
@@ -48,14 +48,14 @@
 
 /* Data structure for MD5 (Message-Digest) computation */
 typedef struct {
-  uint32 i[2];                   /* number of _bits_ handled mod 2^64 */
-  uint32 buf[4];                                    /* scratch buffer */
-  uint8 in[64];                              /* input buffer */
-  uint8 digest[16];     /* actual digest after MD5Final call */
+  uint32_t i[2];                   /* number of _bits_ handled mod 2^64 */
+  uint32_t buf[4];                                    /* scratch buffer */
+  uint8_t in[64];                              /* input buffer */
+  uint8_t digest[16];     /* actual digest after MD5Final call */
 } MD5_CTX;
 
 void MD5Init(MD5_CTX*);
-void MD5Update(MD5_CTX*, uint8*, unsigned int);
+void MD5Update(MD5_CTX*, uint8_t*, unsigned int);
 void MD5Final(MD5_CTX*);
 
 #endif //__MD5_H

--- a/src/core/ntmbs.h
+++ b/src/core/ntmbs.h
@@ -87,7 +87,7 @@ typedef const wchar_t* const_ntwcs_t;
 #    if WCHAR_IS_16_BITS
 typedef wchar_t dbchar_t; // Same size but use NT's type
 #    else
-typedef uint16      dbchar_t;
+typedef uint16_t        dbchar_t;
 #    endif
 typedef dbchar_t*       ntdbs_t;
 typedef const dbchar_t* const_ntdbs_t;
@@ -101,7 +101,7 @@ typedef const dbchar_t* const_ntdbs_t;
 #    if WCHAR_IS_32_BITS
 typedef wchar_t qbchar_t; // Same size but use NT's type
 #    else
-typedef uint32      qbchar_t;
+typedef uint32_t        qbchar_t;
 #    endif
 typedef qbchar_t*       ntqbs_t;
 typedef const qbchar_t* const_ntqbs_t;

--- a/src/core/serializable.h
+++ b/src/core/serializable.h
@@ -78,7 +78,7 @@ class iSerializer;
 class iSerializable
 {
 public:
-    virtual void Read(iSerializer* pSerializer, int32 version = 0) = 0; // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0) = 0; // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const             = 0; // throw (eSerializer, eArchive)
         // objects implement these methods to read and write themselves to a serializer.
 
@@ -93,21 +93,21 @@ public:
     typedef iTypedSerializable* (*CreateFunc)();
     // Pointer to a function that creates an empty version of each typed serializable object
 
-    virtual int32 Version() const = 0;
+    virtual int32_t Version() const = 0;
     // Return the current version of that this serializable object writes.
     // As a convention version number should be (major_version << 16) | minor_version.
 
-    static int32 MkVersion(int16 major, int16 minor)
+    static int32_t MkVersion(int16_t major, int16_t minor)
     {
-        return (int32)(((uint32)major << 16) | (uint32)minor);
+        return (int32_t)(((uint32_t)major << 16) | (uint32_t)minor);
     }
-    static int16 MajorVersion(int32 version)
+    static int16_t MajorVersion(int32_t version)
     {
-        return (int16)((uint32)version >> 16);
+        return (int16_t)((uint32_t)version >> 16);
     }
-    static int16 MinorVersion(int32 version)
+    static int16_t MinorVersion(int32_t version)
     {
-        return (int16)version;
+        return (int16_t)version;
     }
 
     virtual ~iTypedSerializable()
@@ -121,7 +121,7 @@ public:
         DECLARE_TYPED()                      \
     public:                                  \
         static iTypedSerializable* Create(); \
-        virtual int32              Version() const;
+        virtual int32_t            Version() const;
 
 #    define IMPLEMENT_TYPEDSERIALIZABLE(CLASS, TYPEDSTRING, VERSION_MAJOR, VERSION_MINOR) \
         IMPLEMENT_TYPED(CLASS, TYPEDSTRING)                                               \
@@ -129,7 +129,7 @@ public:
         {                                                                                 \
             return new CLASS;                                                             \
         }                                                                                 \
-        int32 CLASS::Version() const                                                      \
+        int32_t CLASS::Version() const                                                      \
         {                                                                                 \
             return iTypedSerializable::MkVersion(VERSION_MAJOR, VERSION_MINOR);           \
         }

--- a/src/core/serializer.h
+++ b/src/core/serializer.h
@@ -127,14 +127,14 @@ public:
 
     // writing interface
     // all of these can throw eArchive
-    virtual void ReadInt16(int16& ret)                   = 0;
-    virtual void ReadInt32(int32& ret)                   = 0;
-    virtual void ReadInt64(int64& ret)                   = 0;
+    virtual void ReadInt16(int16_t& ret)                   = 0;
+    virtual void ReadInt32(int32_t& ret)                   = 0;
+    virtual void ReadInt64(int64_t& ret)                   = 0;
     virtual void ReadString(TSTRING& ret)                = 0;
     virtual int  ReadBlob(void* pBlob, int count)        = 0;
-    virtual void WriteInt16(int16 i)                     = 0;
-    virtual void WriteInt32(int32 i)                     = 0;
-    virtual void WriteInt64(int64 i)                     = 0;
+    virtual void WriteInt16(int16_t i)                     = 0;
+    virtual void WriteInt32(int32_t i)                     = 0;
+    virtual void WriteInt64(int64_t i)                     = 0;
     virtual void WriteString(const TSTRING& s)           = 0;
     virtual void WriteBlob(const void* pBlob, int count) = 0;
 

--- a/src/core/serializerimpl.cpp
+++ b/src/core/serializerimpl.cpp
@@ -44,7 +44,7 @@ cSerializerImpl::SerRefCountMap cSerializerImpl::mSerRefCountCreateMap;
 ///////////////////////////////////////////////////////////////////////////////
 // util_GetCrc -- calculates the crc for the narrow version of the type's AsString()
 ///////////////////////////////////////////////////////////////////////////////
-static uint32 util_GetCRC(const cType& type)
+static uint32_t util_GetCRC(const cType& type)
 {
     //
     // convert this to narrow...
@@ -59,10 +59,10 @@ static uint32 util_GetCRC(const cType& type)
 
     // We only need to count the characters
     // RAD: Yeesh! This is already done for us in cType::mString!!!
-    const uint8* pszType = (const uint8*)(type.AsString());
-    int          nBytes  = ::strlen((const char*)pszType);
+    const uint8_t* pszType = (const uint8_t*)(type.AsString());
+    int            nBytes  = ::strlen((const char*)pszType);
 
-    ASSERT(sizeof(uint8) == sizeof(byte));
+    ASSERT(sizeof(uint8_t) == sizeof(byte));
     ASSERT(pszType && *pszType);
 
     //
@@ -104,7 +104,7 @@ bool cSerializerImpl::IsWriting() const
 
 void cSerializerImpl::RegisterSerializable(const cType& type, iTypedSerializable::CreateFunc pFunc)
 {
-    uint32 crc = util_GetCRC(type);
+    uint32_t crc = util_GetCRC(type);
 
     if (cSerializerImpl::mSerCreateMap.find(crc) != cSerializerImpl::mSerCreateMap.end())
     {
@@ -120,7 +120,7 @@ void cSerializerImpl::RegisterSerializable(const cType& type, iTypedSerializable
 
 void cSerializerImpl::RegisterSerializableRefCt(const cType& type, iSerRefCountObj::CreateFunc pFunc)
 {
-    uint32 crc = util_GetCRC(type);
+    uint32_t crc = util_GetCRC(type);
 
     if (cSerializerImpl::mSerRefCountCreateMap.find(crc) != cSerializerImpl::mSerRefCountCreateMap.end())
     {
@@ -171,17 +171,17 @@ void cSerializerImpl::WriteObjectDynCreate(const iTypedSerializable* pObj)
     //d.TraceDetail("Entering...  Archive Offset = %d\n", mpArchive->CurrentPos());
     d.TraceDetail(_T("             Object Type    = %s\n"), pObj->GetType().AsString());
     // first, we write out the header, which consists of the following:
-    // uint32   crc of the object's type
-    // int32    version of stored data
-    // int32    size of the chunk (counting from this point; not including the previous int32
-    // int32    index into mRefCountObjTbl, or 0 if it isn't refrence counted.
+    // uint32_t   crc of the object's type
+    // int32_t    version of stored data
+    // int32_t    size of the chunk (counting from this point; not including the previous int32
+    // int32_t    index into mRefCountObjTbl, or 0 if it isn't refrence counted.
     //              if the index already exists, then no data follows; a refrence
     //              should just be added to the existing object.
     ASSERT(mpArchive != 0);
 
     // get the ident for this class type
     //
-    uint32 crc = util_GetCRC(pObj->GetType());
+    uint32_t crc = util_GetCRC(pObj->GetType());
 
     //
     // make sure this type is registered, and figure out if it is refrence counted
@@ -243,20 +243,20 @@ iTypedSerializable* cSerializerImpl::ReadObjectDynCreate()
     cDebug d("cSerializerImpl::ReadObjectDynCreate");
     //d.TraceDetail("Entering... archive offset = %d\n", mpArchive->CurrentPos());
 
-    int32  size, objIdx;
-    uint32 crc;
+    int32_t  size, objIdx;
+    uint32_t crc;
     // first, get the type...
-    mpArchive->ReadInt32(reinterpret_cast<int32&>(crc));
+    mpArchive->ReadInt32(reinterpret_cast<int32_t&>(crc));
 
     // read in the version
-    int32 version;
+    int32_t version;
     mpArchive->ReadInt32(version);
 
     // read in the size and the index...
     mpArchive->ReadInt32(size);
 
     // Save the position so we can seek correctly later on
-    //int64 sizePos = mpArchive->CurrentPos();
+    //int64_t sizePos = mpArchive->CurrentPos();
 
     mpArchive->ReadInt32(objIdx);
     if (objIdx == 0)
@@ -272,7 +272,7 @@ iTypedSerializable* cSerializerImpl::ReadObjectDynCreate()
             TOSTRINGSTREAM str;
 #ifdef DEBUG
             // Let's only report the actual crc in debug mode
-            str << (int32)crc << std::ends;
+            str << (int32_t)crc << std::ends;
 #endif
             ThrowAndAssert(eSerializerUnknownType(str.str(), mFileName, eSerializer::TY_FILE));
         }
@@ -300,7 +300,7 @@ iTypedSerializable* cSerializerImpl::ReadObjectDynCreate()
                 // unable to find the creation function...
                 d.TraceError("Unable to find creation function for ref counted object %d\n", crc);
                 TOSTRINGSTREAM str;
-                str << (int32)crc << std::ends;
+                str << (int32_t)crc << std::ends;
                 ThrowAndAssert(eSerializerUnknownType(str.str(), mFileName, eSerializer::TY_FILE));
             }
             pObj = ((*rci).second)();
@@ -342,9 +342,9 @@ void cSerializerImpl::WriteObject(const iTypedSerializable* pObj)
     //d.TraceDetail("Entering...  Archive Offset = %d\n", mpArchive->CurrentPos());
     d.TraceDetail("             Object Type    = %s\n", pObj->GetType().AsString());
     // first, we write out the header, which consists of the following:
-    // int32 refrence into mTypeArray, indicating the object's type
-    // int32 version of stored data
-    // int32 size of the chunk (counting from this point; not including the previous int32
+    // int32_t refrence into mTypeArray, indicating the object's type
+    // int32_t version of stored data
+    // int32_t size of the chunk (counting from this point; not including the previous int32
     // data  the object data
     ASSERT(mpArchive != 0);
 
@@ -375,16 +375,16 @@ void cSerializerImpl::WriteObject(const iTypedSerializable* pObj)
     mpArchive->WriteInt32(0); // place holder for type array index
     mpArchive->WriteInt32(pObj->Version());
     // write a placeholder for the size; we will come back and fill in the right value later...
-    //int64 sizePos = mpArchive->CurrentPos();
+    //int64_t sizePos = mpArchive->CurrentPos();
     mpArchive->WriteInt32(0xffffffff);
 
     // write out the object!
     pObj->Write(this);
 
     // finally, we need to go back and patch up the size...
-    //int64 returnPos = mpArchive->CurrentPos();
+    //int64_t returnPos = mpArchive->CurrentPos();
     //mpArchive->Seek(sizePos, cBidirArchive::BEGINNING);
-    //mpArchive->WriteInt32((int32)(returnPos - sizePos - sizeof(int32)));
+    //mpArchive->WriteInt32((int32_t)(returnPos - sizePos - sizeof(int32_t)));
     //mpArchive->Seek(returnPos, cBidirArchive::BEGINNING);
 }
 
@@ -394,7 +394,7 @@ void cSerializerImpl::ReadObject(iTypedSerializable* pObj)
     //d.TraceDetail("Entering... archive offset = %d\n", mpArchive->CurrentPos());
 
     // NOTE -- type index stuff is gone; see the comment in WriteObject()
-    int32 /*typeIdx,*/ size;
+    int32_t /*typeIdx,*/ size;
     // first, get the type...
     /*
     mpArchive->ReadInt32(typeIdx);
@@ -408,7 +408,7 @@ void cSerializerImpl::ReadObject(iTypedSerializable* pObj)
     */
 
     // read in the version
-    int32 dummy, version;
+    int32_t dummy, version;
     mpArchive->ReadInt32(dummy); // old type array index
     mpArchive->ReadInt32(version);
 
@@ -424,7 +424,7 @@ void cSerializerImpl::ReadObject(iTypedSerializable* pObj)
     }
 
     // remember current position
-    //int64 sizePos = mpArchive->CurrentPos();
+    //int64_t sizePos = mpArchive->CurrentPos();
 
     // read in the object!
     pObj->Read(this, version);
@@ -437,17 +437,17 @@ void cSerializerImpl::ReadObject(iTypedSerializable* pObj)
 ///////////////////////////////////////////////////////////////////////////////
 // archive wrapper
 ///////////////////////////////////////////////////////////////////////////////
-void cSerializerImpl::ReadInt16(int16& ret)
+void cSerializerImpl::ReadInt16(int16_t& ret)
 {
     mpArchive->ReadInt16(ret);
 }
 
-void cSerializerImpl::ReadInt32(int32& ret)
+void cSerializerImpl::ReadInt32(int32_t& ret)
 {
     mpArchive->ReadInt32(ret);
 }
 
-void cSerializerImpl::ReadInt64(int64& ret)
+void cSerializerImpl::ReadInt64(int64_t& ret)
 {
     mpArchive->ReadInt64(ret);
 }
@@ -462,17 +462,17 @@ int cSerializerImpl::ReadBlob(void* pBlob, int count)
     return mpArchive->ReadBlob(pBlob, count);
 }
 
-void cSerializerImpl::WriteInt16(int16 i)
+void cSerializerImpl::WriteInt16(int16_t i)
 {
     mpArchive->WriteInt16(i);
 }
 
-void cSerializerImpl::WriteInt32(int32 i)
+void cSerializerImpl::WriteInt32(int32_t i)
 {
     mpArchive->WriteInt32(i);
 }
 
-void cSerializerImpl::WriteInt64(int64 i)
+void cSerializerImpl::WriteInt64(int64_t i)
 {
     mpArchive->WriteInt64(i);
 }

--- a/src/core/serializerimpl.h
+++ b/src/core/serializerimpl.h
@@ -100,14 +100,14 @@ public:
     // I think the best thing might be to have iSerializable only know about the archive
     // Standard data read/write
     // (All functions can throw eArchave exceptions).
-    virtual void ReadInt16(int16& ret);
-    virtual void ReadInt32(int32& ret);
-    virtual void ReadInt64(int64& ret);
+    virtual void ReadInt16(int16_t& ret);
+    virtual void ReadInt32(int32_t& ret);
+    virtual void ReadInt64(int64_t& ret);
     virtual void ReadString(TSTRING& ret);
     virtual int  ReadBlob(void* pBlob, int count);
-    virtual void WriteInt16(int16 i);
-    virtual void WriteInt32(int32 i);
-    virtual void WriteInt64(int64 i);
+    virtual void WriteInt16(int16_t i);
+    virtual void WriteInt32(int32_t i);
+    virtual void WriteInt64(int64_t i);
     virtual void WriteString(const TSTRING& s);
     virtual void WriteBlob(const void* pBlob, int count);
 
@@ -122,8 +122,8 @@ private:
     TSTRING mFileName;
 
     // creation function maps
-    typedef std::map<uint32, iTypedSerializable::CreateFunc> SerMap;
-    typedef std::map<uint32, iSerRefCountObj::CreateFunc>    SerRefCountMap;
+    typedef std::map<uint32_t, iTypedSerializable::CreateFunc> SerMap;
+    typedef std::map<uint32_t, iSerRefCountObj::CreateFunc>    SerRefCountMap;
     static SerMap                                            mSerCreateMap;
     static SerRefCountMap                                    mSerRefCountCreateMap;
 

--- a/src/core/serializerutil.cpp
+++ b/src/core/serializerutil.cpp
@@ -37,18 +37,18 @@
 
 namespace
 {
-template<class FROM, class TO> int64 CopyImpl(TO* pTo, FROM* pFrom, int64 amt)
+template<class FROM, class TO> int64_t CopyImpl(TO* pTo, FROM* pFrom, int64_t amt)
 {
     enum
     {
         BUF_SIZE = 8192
     };
-    int8  buf[BUF_SIZE];
-    int64 amtLeft = amt;
+    int8_t  buf[BUF_SIZE];
+    int64_t amtLeft = amt;
 
     while (amtLeft > 0)
     {
-        // NOTE: We use int's here rather than int64 because iSerializer and cArchive
+        // NOTE: We use int's here rather than int64_t because iSerializer and cArchive
         // only take int's as their size parameter - dmb
         int amtToRead = amtLeft > BUF_SIZE ? BUF_SIZE : (int)amtLeft;
         int amtRead   = pFrom->ReadBlob(buf, amtToRead);
@@ -64,12 +64,12 @@ template<class FROM, class TO> int64 CopyImpl(TO* pTo, FROM* pFrom, int64 amt)
 } // namespace
 
 
-int64 cSerializerUtil::Copy(iSerializer* pDest, cArchive* pSrc, int64 amt)
+int64_t cSerializerUtil::Copy(iSerializer* pDest, cArchive* pSrc, int64_t amt)
 {
     return CopyImpl(pDest, pSrc, amt);
 }
 
-int64 cSerializerUtil::Copy(cArchive* pDest, iSerializer* pSrc, int64 amt)
+int64_t cSerializerUtil::Copy(cArchive* pDest, iSerializer* pSrc, int64_t amt)
 {
     return CopyImpl(pDest, pSrc, amt);
 }

--- a/src/core/serializerutil.h
+++ b/src/core/serializerutil.h
@@ -44,8 +44,8 @@ class iSerializer;
 class cSerializerUtil
 {
 public:
-    static int64 Copy(iSerializer* pDest, cArchive* pSrc, int64 amt); // throw( eArchvie, eSerilaizer )
-    static int64 Copy(cArchive* pDest, iSerializer* pSrc, int64 amt); // throw( eArchvie, eSerilaizer )
+    static int64_t Copy(iSerializer* pDest, cArchive* pSrc, int64_t amt); // throw( eArchvie, eSerilaizer )
+    static int64_t Copy(cArchive* pDest, iSerializer* pSrc, int64_t amt); // throw( eArchvie, eSerilaizer )
         // these two methods copy data from archives to serializers and vice-versa. They
         // throw exceptions on error; the return value is the amount that was copied.
 };

--- a/src/core/serstring.cpp
+++ b/src/core/serstring.cpp
@@ -37,9 +37,9 @@
 
 IMPLEMENT_TYPEDSERIALIZABLE(cSerializableNString, _T("cSerializableNString"), 0, 1)
 
-void cSerializableNString::Read(iSerializer* pSerializer, int32 version)
+void cSerializableNString::Read(iSerializer* pSerializer, int32_t version)
 {
-    int32 len;
+    int32_t len;
     pSerializer->ReadInt32(len);
     mString.resize(len);
     pSerializer->ReadBlob((void*)mString.data(), len); // note len is the bytelen of the data
@@ -47,7 +47,7 @@ void cSerializableNString::Read(iSerializer* pSerializer, int32 version)
 
 void cSerializableNString::Write(iSerializer* pSerializer) const
 {
-    int32 len = mString.length() * sizeof(char);
+    int32_t len = mString.length() * sizeof(char);
     pSerializer->WriteInt32(len);
     pSerializer->WriteBlob(mString.data(), len);
 }
@@ -55,9 +55,9 @@ void cSerializableNString::Write(iSerializer* pSerializer) const
 
 IMPLEMENT_TYPEDSERIALIZABLE(cSerializableWString, _T("cSerializableWString"), 0, 1)
 
-void cSerializableWString::Read(iSerializer* pSerializer, int32 version)
+void cSerializableWString::Read(iSerializer* pSerializer, int32_t version)
 {
-    int32 len;
+    int32_t len;
     pSerializer->ReadInt32(len);
     mString.resize(len);
     pSerializer->ReadBlob((void*)mString.data(), len); // note len is the bytelen of the data
@@ -65,7 +65,7 @@ void cSerializableWString::Read(iSerializer* pSerializer, int32 version)
 
 void cSerializableWString::Write(iSerializer* pSerializer) const
 {
-    int32 len = mString.length() * sizeof(wchar_t);
+    int32_t len = mString.length() * sizeof(wchar_t);
     pSerializer->WriteInt32(len);
     pSerializer->WriteBlob(mString.data(), len);
 }

--- a/src/core/serstring.h
+++ b/src/core/serstring.h
@@ -57,7 +57,7 @@ public:
     std::string mString;
 
     virtual ~cSerializableNString(){};
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 
     DECLARE_TYPEDSERIALIZABLE()
@@ -72,7 +72,7 @@ public:
     std::string mString;
 
     virtual ~cSerializableWString(){};
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 
     DECLARE_TYPEDSERIALIZABLE()

--- a/src/core/sha.cpp
+++ b/src/core/sha.cpp
@@ -149,8 +149,8 @@
 
 /* The two buffers of 5 32-bit words */
 
-uint32 h0, h1, h2, h3, h4;
-uint32 A, B, C, D, E;
+uint32_t h0, h1, h2, h3, h4;
+uint32_t A, B, C, D, E;
 
 /* Initialize the SHS values */
 
@@ -173,7 +173,7 @@ void shsInit(SHS_INFO* shsInfo)
 
 void shsTransform(SHS_INFO *shsInfo)
 {
-    uint32 W[ 80 ], temp;
+    uint32_t W[ 80 ], temp;
     int i;
 
     /* Step A.  Copy the data buffer into the local work buffer */
@@ -240,12 +240,12 @@ void shsTransform(SHS_INFO *shsInfo)
    makes for very slow code, so we rely on the user to sort out endianness
    at compile time */
 
-static void byteReverse(uint32* buffer, int byteCount)
+static void byteReverse(uint32_t* buffer, int byteCount)
     {
-    uint32 value;
+    uint32_t value;
     int count;
 
-    byteCount /= sizeof( uint32 );
+    byteCount /= sizeof( uint32_t );
     for( count = 0; count < byteCount; count++ )
     {
     value = ( buffer[ count ] << 16 ) | ( buffer[ count ] >> 16 );
@@ -259,13 +259,13 @@ static void byteReverse(uint32* buffer, int byteCount)
    more efficient since it does away with the need to handle partial blocks
    between calls to shsUpdate() */
 
-void shsUpdate(SHS_INFO* shsInfo, uint8* buffer, int count)
+void shsUpdate(SHS_INFO* shsInfo, uint8_t* buffer, int count)
     {
     /* Update bitcount */
-    if( ( shsInfo->countLo + ( ( uint32 ) count << 3 ) ) < shsInfo->countLo )
+    if( ( shsInfo->countLo + ( ( uint32_t ) count << 3 ) ) < shsInfo->countLo )
     shsInfo->countHi++; /* Carry from low to high bitCount */
-    shsInfo->countLo += ( ( uint32 ) count << 3 );
-    shsInfo->countHi += ( ( uint32 ) count >> 29 );
+    shsInfo->countLo += ( ( uint32_t ) count << 3 );
+    shsInfo->countHi += ( ( uint32_t ) count >> 29 );
 
     /* Process data in SHS_BLOCKSIZE chunks */
     while( count >= SHS_BLOCKSIZE )
@@ -287,14 +287,14 @@ void shsUpdate(SHS_INFO* shsInfo, uint8* buffer, int count)
 void shsFinal(SHS_INFO *shsInfo)
 {
     int count;
-    uint32 lowBitcount = shsInfo->countLo, highBitcount = shsInfo->countHi;
+    uint32_t lowBitcount = shsInfo->countLo, highBitcount = shsInfo->countHi;
 
     /* Compute number of bytes mod 64 */
     count = ( int ) ( ( shsInfo->countLo >> 3 ) & 0x3F );
 
     /* Set the first char of padding to 0x80.  This is safe since there is
        always at least one byte free */
-    ( ( uint8 * ) shsInfo->data )[ count++ ] = 0x80;
+    ( ( uint8_t * ) shsInfo->data )[ count++ ] = 0x80;
 
     /* Pad out to 56 mod 64 */
     if( count > 56 )
@@ -343,14 +343,14 @@ void main()
     {
     SHS_INFO shsInfo;
     time_t endTime, startTime;
-    uint8 data[ TEST_BLOCK_SIZE ];
+    uint8_t data[ TEST_BLOCK_SIZE ];
     long i;
 
     /* Test output data (this is the only test data given in the SHS
        document, but chances are if it works for this it'll work for
        anything) */
     shsInit( &shsInfo );
-    shsUpdate( &shsInfo, ( uint8 * ) "abc", 3 );
+    shsUpdate( &shsInfo, ( uint8_t * ) "abc", 3 );
     shsFinal( &shsInfo );
     if( shsInfo.digest[ 0 ] != 0x0164B8A9L ||
     shsInfo.digest[ 1 ] != 0x14CD2A5EL ||

--- a/src/core/sha.h
+++ b/src/core/sha.h
@@ -46,16 +46,16 @@
 /* The structure for storing SHS info */
 
 typedef struct {
-           uint32 digest[ 5 ];            /* Message digest */
-           uint32 countLo, countHi;       /* 64-bit bit count */
-           uint32 data[ 16 ];             /* SHS data buffer */
+           uint32_t digest[ 5 ];            /* Message digest */
+           uint32_t countLo, countHi;       /* 64-bit bit count */
+           uint32_t data[ 16 ];             /* SHS data buffer */
            } SHS_INFO;
 
 /* Whether the machine is little-endian or not */
 
 //int sig_sha_get();
 void shsInit(SHS_INFO *shsInfo);
-void shsUpdate(SHS_INFO* shsInfo, uint8* buffer, int count);
+void shsUpdate(SHS_INFO* shsInfo, uint8_t* buffer, int count);
 void shsFinal(SHS_INFO* shsInfo);
 
 /* The next def turns on the change to the algorithm introduced by NIST at

--- a/src/core/srefcountobj.h
+++ b/src/core/srefcountobj.h
@@ -66,8 +66,8 @@ protected:
 #    define DECLARE_SERREFCOUNT()         \
         DECLARE_TYPED()                   \
     public:                               \
-        static iSerRefCountObj* Create(); \
-        virtual int32           Version() const;
+        static iSerRefCountObj*   Create(); \
+        virtual int32_t           Version() const;
 
 #    define IMPLEMENT_SERREFCOUNT(CLASS, TYPEDSTRING, VERSION_MAJOR, VERSION_MINOR) \
         IMPLEMENT_TYPED(CLASS, TYPEDSTRING)                                         \
@@ -75,7 +75,7 @@ protected:
         {                                                                           \
             return new CLASS;                                                       \
         }                                                                           \
-        int32 CLASS::Version() const                                                \
+        int32_t CLASS::Version() const                                                \
         {                                                                           \
             return iTypedSerializable::MkVersion(VERSION_MAJOR, VERSION_MINOR);     \
         }

--- a/src/core/tasktimer.h
+++ b/src/core/tasktimer.h
@@ -96,11 +96,11 @@ public:
     {
         mNumStarts = mStartTime = mTotalTime = 0;
     }
-    uint32 GetTotalTime() const
+    uint32_t GetTotalTime() const
     {
         return mTotalTime;
     }
-    uint32 GetNumTimesStarted() const
+    uint32_t GetNumTimesStarted() const
     {
         return mNumStarts;
     }
@@ -110,10 +110,10 @@ public:
     }
 
 private:
-    TSTRING mName;
-    uint32  mTotalTime;
-    uint32  mStartTime;
-    uint32  mNumStarts;
+    TSTRING   mName;
+    uint32_t  mTotalTime;
+    uint32_t  mStartTime;
+    uint32_t  mNumStarts;
 };
 
 

--- a/src/core/timeconvert.cpp
+++ b/src/core/timeconvert.cpp
@@ -58,14 +58,14 @@
 #    define tzset()
 #endif
 
-struct tm* cTimeUtil::TimeToDateGMT(const int64& seconds)
+struct tm* cTimeUtil::TimeToDateGMT(const int64_t& seconds)
 {
     ASSERT(seconds < TIME_MAX); // this assumes time_t size is 32 bit.  Yikes!
     time_t t = static_cast<time_t>(seconds);
     return gmtime(&t);
 }
 
-struct tm* cTimeUtil::TimeToDateLocal(const int64& seconds)
+struct tm* cTimeUtil::TimeToDateLocal(const int64_t& seconds)
 {
     ASSERT(seconds < TIME_MAX); // this assumes time_t size is 32 bit.  Yikes!
     time_t t = static_cast<time_t>(seconds);
@@ -73,13 +73,13 @@ struct tm* cTimeUtil::TimeToDateLocal(const int64& seconds)
     return localtime(&t);
 }
 
-int64 cTimeUtil::DateToTime(struct tm* ptm)
+int64_t cTimeUtil::DateToTime(struct tm* ptm)
 {
     tzset();
     return mktime(ptm);
 }
 
-int64 cTimeUtil::GetTime()
+int64_t cTimeUtil::GetTime()
 {
     return time(NULL);
 }

--- a/src/core/timeconvert.h
+++ b/src/core/timeconvert.h
@@ -62,13 +62,13 @@
 class cTimeUtil
 {
 public:
-    static int64 DateToTime(struct tm* ptm);
+    static int64_t DateToTime(struct tm* ptm);
     // simple conversion.  ptm is considered to be in localtime.
-    static struct tm* TimeToDateGMT(const int64& seconds);
+    static struct tm* TimeToDateGMT(const int64_t& seconds);
     // simple conversion
-    static struct tm* TimeToDateLocal(const int64& seconds);
+    static struct tm* TimeToDateLocal(const int64_t& seconds);
     // conversion with timezone and daylight
-    static int64 GetTime();
+    static int64_t GetTime();
     // returns current time in UTC
 };
 

--- a/src/core/twlocale.cpp
+++ b/src/core/twlocale.cpp
@@ -104,12 +104,12 @@ void cTWLocale::InitGlobalLocale()
 }
 
 /*
-TSTRING cTWLocale::FormatNumberAsHex( int32 i )
+TSTRING cTWLocale::FormatNumberAsHex( int32_t i )
 {
     //
     // preconditions
     //
-    ASSERT( sizeof( long ) >= sizeof( int32 ) ); // must be able to cast to 'long'
+    ASSERT( sizeof( long ) >= sizeof( int32_t ) ); // must be able to cast to 'long'
 
     //
     // convert long to a string
@@ -181,27 +181,27 @@ public:
 };
 
 /*
-TSTRING cTWLocale::FormatNumberClassic( int32 i )
+TSTRING cTWLocale::FormatNumberClassic( int32_t i )
 {
     TSTRING s;
     return cFormatNumberUtil< long, TCHAR >::Format( i, s, true );
 }
 
-int32 cTWLocale::FormatNumberClassic( const TSTRING& s )
+int32_t cTWLocale::FormatNumberClassic( const TSTRING& s )
 {
     return cFormatNumberUtil< long, TCHAR >::Format( s, true );
 }
 */
 
-TSTRING& cTWLocale::FormatNumber(uint64 ui, TSTRING& strBuf)
+TSTRING& cTWLocale::FormatNumber(uint64_t ui, TSTRING& strBuf)
 {
-    // try to use the int64 version
-    if (ui <= (uint64)TSS_INT64_MAX)
-        return (FormatNumber((int64)ui, strBuf));
+    // try to use the int64_t version
+    if (ui <= (uint64_t)TSS_INT64_MAX)
+        return (FormatNumber((int64_t)ui, strBuf));
     else
     {
 #if IS_MSVC
-        // MSVC can't convert from uint64 to a double for some reason
+        // MSVC can't convert from uint64_t to a double for some reason
         strBuf = TSS_GetString(cCore, core::STR_NUMBER_TOO_BIG);
         return (strBuf);
 #else
@@ -211,11 +211,11 @@ TSTRING& cTWLocale::FormatNumber(uint64 ui, TSTRING& strBuf)
     }
 }
 
-TSTRING& cTWLocale::FormatNumber(int64 i, TSTRING& strBuf)
+TSTRING& cTWLocale::FormatNumber(int64_t i, TSTRING& strBuf)
 {
-    // try to use the int32 version
-    if (i <= (int64)TSS_INT32_MAX)
-        return (FormatNumber((int32)i, strBuf));
+    // try to use the int32_t version
+    if (i <= (int64_t)TSS_INT32_MAX)
+        return (FormatNumber((int32_t)i, strBuf));
     else
     {
         ASSERT(std::numeric_limits<double>::max() >= TSS_INT64_MAX);
@@ -223,19 +223,19 @@ TSTRING& cTWLocale::FormatNumber(int64 i, TSTRING& strBuf)
     }
 }
 
-TSTRING& cTWLocale::FormatNumber(uint32 ui, TSTRING& strBuf)
+TSTRING& cTWLocale::FormatNumber(uint32_t ui, TSTRING& strBuf)
 {
-    ASSERT(sizeof(unsigned long) >= sizeof(uint32)); // must be able to cast to 'ulong'
+    ASSERT(sizeof(unsigned long) >= sizeof(uint32_t)); // must be able to cast to 'ulong'
     return (cFormatNumberUtil<unsigned long, TCHAR>::Format((unsigned long)ui, strBuf));
 }
 
-TSTRING& cTWLocale::FormatNumber(int32 i, TSTRING& strBuf)
+TSTRING& cTWLocale::FormatNumber(int32_t i, TSTRING& strBuf)
 {
-    ASSERT(sizeof(long) >= sizeof(int32)); // must be able to cast to 'long'
+    ASSERT(sizeof(long) >= sizeof(int32_t)); // must be able to cast to 'long'
     return (cFormatNumberUtil<long, TCHAR>::Format((long)i, strBuf));
 }
 
-TSTRING& cTWLocale::FormatTime(int64 t, TSTRING& strBuf)
+TSTRING& cTWLocale::FormatTime(int64_t t, TSTRING& strBuf)
 {
     // clear return string
     strBuf.erase();

--- a/src/core/twlocale.h
+++ b/src/core/twlocale.h
@@ -73,22 +73,22 @@ public:
     //
     // basic functionality
     //
-    static TSTRING& FormatNumber(int32 i, TSTRING& strBuf);
-    static TSTRING& FormatNumber(int64 i, TSTRING& strBuf);
-    static TSTRING& FormatNumber(uint32 ui, TSTRING& strBuf);
-    static TSTRING& FormatNumber(uint64 ui, TSTRING& strBuf);
+    static TSTRING& FormatNumber(int32_t   i, TSTRING& strBuf);
+    static TSTRING& FormatNumber(int64_t   i, TSTRING& strBuf);
+    static TSTRING& FormatNumber(uint32_t ui, TSTRING& strBuf);
+    static TSTRING& FormatNumber(uint64_t ui, TSTRING& strBuf);
     static TSTRING& FormatNumber(double d, TSTRING& strBuf);
     // returns the locale-specific representation of the given cardinal number
     /*
-    static TSTRING  FormatNumberClassic( int32 i );
-    static int32    FormatNumberClassic( const TSTRING& s );
+    static TSTRING  FormatNumberClassic( int32_t i );
+    static int32_t    FormatNumberClassic( const TSTRING& s );
         // returns the C-locale representation of the given cardinal number
 */
     //      disabled this since nobody's using it
-    //    static TSTRING  FormatNumberAsHex( int32 x );
+    //    static TSTRING  FormatNumberAsHex( int32_t x );
     // locale-independant
 
-    static TSTRING& FormatTime(int64 t, TSTRING& strBuf);
+    static TSTRING& FormatTime(int64_t t, TSTRING& strBuf);
     // returns the local time and date formatted according to the current locale.
     // t is the number of seconds elapsed since midnight (00:00:00),
     // January 1, 1970, coordinated universal time

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -44,48 +44,40 @@
 //-----------------------------------------------------------------------------
 // standard TSS types
 //-----------------------------------------------------------------------------
-#if __cplusplus < 201103L
-typedef unsigned char uint8_t;
-#endif
+#if !HAVE_STDINT_H
+typedef unsigned char  uint8_t;
+typedef signed char    int8_t;
+typedef short          int16_t;
+typedef unsigned short uint16_t;
 
-typedef signed char    int8;
-typedef short          int16;
-typedef float          float32;
-typedef double         float64;
-typedef unsigned char  uint8;
-typedef unsigned short uint16;
+//typedef float          float32_t;
+//typedef double         float64_t;
 
-#if HAVE_STDINT_H
-typedef int32_t  int32;
-typedef uint32_t uint32;
-
-#elif SIZEOF_INT == 4
-typedef int           int32;
-typedef unsigned int  uint32;
+#if SIZEOF_INT == 4
+typedef int           int32_t;
+typedef unsigned int  uint32_t;
 
 #elif SIZEOF_LONG == 4
-typedef long               int32;
-typedef unsigned long      uint32;
+typedef long               int32_t;
+typedef unsigned long      uint32_t;
 #else
 #    error "I don't seem to have a 32-bit integer type on this system."
 #endif
 
-#if HAVE_STDINT_H
-typedef int64_t  int64;
-typedef uint64_t uint64;
-#elif SIZEOF_LONG == 8
-typedef long          int64;
-typedef unsigned long uint64;
+#if SIZEOF_LONG == 8
+typedef long          int64_t;
+typedef unsigned long uint64_t;
 #elif SIZEOF_LONG_LONG == 8
-typedef long long          int64;
-typedef unsigned long long uint64;
+typedef long long          int64_t;
+typedef unsigned long long uint64_t;
 #else
 #    error "I don't seem to have a 64-bit integer type on this system."
 #endif
+#endif // !HAVE_STDINT_H
 
 // other Win32 definitions
 //typedef uint16                UINT;
-//typedef uint32                DWORD;
+//typedef uint32_t                DWORD;
 
 //-----------------------------------------------------------------------------
 // Limits -- should be platform independent, right? ( assumes 2's complement numbers )
@@ -153,23 +145,23 @@ namespace std
 // Byte Swapping
 //-----------------------------------------------------------------------------
 
-inline int16 SWAPBYTES16(int16 i)
+inline int16_t SWAPBYTES16(int16_t i)
 {
 
-    return ((uint16)i >> 8) | ((uint16)i << 8);
+    return ((uint16_t)i >> 8) | ((uint16_t)i << 8);
 }
 
-inline int32 SWAPBYTES32(int32 i)
+inline int32_t SWAPBYTES32(int32_t i)
 {
-    return ((uint32)i >> 24) | (((uint32)i & 0x00ff0000) >> 8) | (((uint32)i & 0x0000ff00) << 8) | ((uint32)i << 24);
+    return ((uint32_t)i >> 24) | (((uint32_t)i & 0x00ff0000) >> 8) | (((uint32_t)i & 0x0000ff00) << 8) | ((uint32_t)i << 24);
 }
 
-inline int64 SWAPBYTES64(int64 i)
+inline int64_t SWAPBYTES64(int64_t i)
 {
-    return ((uint64)i >> 56) | (((uint64)i & 0x00ff000000000000ULL) >> 40) |
-           (((uint64)i & 0x0000ff0000000000ULL) >> 24) | (((uint64)i & 0x000000ff00000000ULL) >> 8) |
-           (((uint64)i & 0x00000000ff000000ULL) << 8) | (((uint64)i & 0x0000000000ff0000ULL) << 24) |
-           (((uint64)i & 0x000000000000ff00ULL) << 40) | ((uint64)i << 56);
+    return ((uint64_t)i >> 56) | (((uint64_t)i & 0x00ff000000000000ULL) >> 40) |
+           (((uint64_t)i & 0x0000ff0000000000ULL) >> 24) | (((uint64_t)i & 0x000000ff00000000ULL) >> 8) |
+           (((uint64_t)i & 0x00000000ff000000ULL) << 8) | (((uint64_t)i & 0x0000000000ff0000ULL) << 24) |
+           (((uint64_t)i & 0x000000000000ff00ULL) << 40) | ((uint64_t)i << 56);
 }
 
 
@@ -179,7 +171,7 @@ inline int64 SWAPBYTES64(int64 i)
 #        define tw_ntohl(x) (x)
 #        define tw_htons(x) (x)
 #        define tw_ntohs(x) (x)
-#        define tw_htonll(x) (x) // int64 versions
+#        define tw_htonll(x) (x) // int64_t versions
 #        define tw_ntohll(x) (x)
 
 #    else //!WORDS_BIGENDIAN
@@ -188,7 +180,7 @@ inline int64 SWAPBYTES64(int64 i)
 #        define tw_ntohl(x) SWAPBYTES32((x))
 #        define tw_htons(x) SWAPBYTES16((x))
 #        define tw_ntohs(x) SWAPBYTES16((x))
-#        define tw_htonll(x) SWAPBYTES64((x)) // int64 versions
+#        define tw_htonll(x) SWAPBYTES64((x)) // int64_t versions
 #        define tw_ntohll(x) SWAPBYTES64((x))
 
 #    endif //WORDS_BIGENDIAN

--- a/src/core/unixfsservices.cpp
+++ b/src/core/unixfsservices.cpp
@@ -479,7 +479,7 @@ bool cUnixFSServices::GetCurrentUserName(TSTRING& strName) const
 
 
 // returns IP address in network byte order
-bool cUnixFSServices::GetIPAddress(uint32& uiIPAddress)
+bool cUnixFSServices::GetIPAddress(uint32_t& uiIPAddress)
 {
     bool   fGotAddress = false;
     cDebug d(_T("cUnixFSServices::GetIPAddress"));
@@ -495,13 +495,13 @@ bool cUnixFSServices::GetIPAddress(uint32& uiIPAddress)
         if (phostent)
         {
             ASSERT(AF_INET == phostent->h_addrtype);
-            ASSERT(sizeof(int32) == phostent->h_length);
+            ASSERT(sizeof(int32_t) == phostent->h_length);
 
             if (phostent->h_length)
             {
                 if (phostent->h_addr_list[0])
                 {
-                    int32* pAddress = reinterpret_cast<int32*>(phostent->h_addr_list[0]);
+                    int32_t* pAddress = reinterpret_cast<int32_t*>(phostent->h_addr_list[0]);
                     uiIPAddress     = *pAddress;
                     fGotAddress     = true;
                 }
@@ -600,21 +600,21 @@ bool cUnixFSServices::GetGroupName(gid_t group_id, TSTRING& tstrGroup) const
 //
 // Returns          : void -- no errors are reported
 //
-// Argument         : uint64 perm -- st_mode from "stat"
+// Argument         : uint64_t perm -- st_mode from "stat"
 // Argument         : TSTRING& tstrPerm -- converted permissions, ls -l style
 //
-void cUnixFSServices::ConvertModeToString(uint64 perm, TSTRING& tstrPerm) const
+void cUnixFSServices::ConvertModeToString(uint64_t perm, TSTRING& tstrPerm) const
 {
     TCHAR szPerm[12]; //10 permission bits plus the NULL
     strncpy(szPerm, _T("----------"), 11);
 
-    ASSERT(sizeof(unsigned short) <= sizeof(uint32));
+    ASSERT(sizeof(unsigned short) <= sizeof(uint32_t));
     // We do this in case an "unsigned short" is ever larger than the
     // value we are switching on, since the size of the mode parameter
     // will be unsigned short (whatever that means, for the given platform...)
 
     // check file type
-    switch ((uint32)perm & S_IFMT) //some versions of Unix don't like to switch on
+    switch ((uint32_t)perm & S_IFMT) //some versions of Unix don't like to switch on
                                    //64 bit values.
     {
     case S_IFDIR:

--- a/src/core/unixfsservices.h
+++ b/src/core/unixfsservices.h
@@ -109,7 +109,7 @@ public:
 
     virtual bool GetCurrentUserName(TSTRING& tstrName) const;
 
-    virtual bool GetIPAddress(uint32& uiIPAddress);
+    virtual bool GetIPAddress(uint32_t& uiIPAddress);
 
 
     ////////////////////////////////////////
@@ -143,8 +143,8 @@ public:
     ////////////////////////////////////////
     // miscellaneous utility functions
     ////////////////////////////////////////
-    virtual void ConvertModeToString(uint64 perm, TSTRING& tstrPerm) const;
-    // takes a int64 permission (from stat) and changes it to look like UNIX's 'ls -l' (e.g. drwxrwxrwx)
+    virtual void ConvertModeToString(uint64_t perm, TSTRING& tstrPerm) const;
+    // takes a int64_t permission (from stat) and changes it to look like UNIX's 'ls -l' (e.g. drwxrwxrwx)
     virtual bool FullPath(TSTRING& fullPath, const TSTRING& relPath, const TSTRING& pathRelFrom = _T("")) const;
     // converts relPath into a fully qualified path, storing it in FullPath. If this
     // fails, false is returned.  if the path to which relPath is relative is not CWD, put it in pathRelFrom.

--- a/src/core/wchar16.h
+++ b/src/core/wchar16.h
@@ -43,11 +43,7 @@
 #include "types.h"
 #endif
 
-#if WCHAR_IS_16_BITS
-typedef unsigned short WCHAR16;
-#else
-typedef uint16 WCHAR16; // unix has 4 byte wchar_t, but we want to standardize on 16 bit wide chars
-#endif
+typedef uint16_t WCHAR16; // unix has 4 byte wchar_t, but we want to standardize on 16 bit wide chars
 
 //=============================================================================
 // class wc16_string

--- a/src/cryptlib/config.h
+++ b/src/cryptlib/config.h
@@ -102,10 +102,10 @@ typedef unsigned short word16;
 
 #if defined(_MSC_VER)
 
-typedef unsigned __int32 word;
-typedef unsigned __int64 dword;
+typedef unsigned __int32_t word;
+typedef unsigned __int64_t dword;
 #define WORD64_AVAILABLE
-typedef unsigned __int64 word64;
+typedef unsigned __int64_t word64;
 #define W64LIT(x) x##i64
 
 #elif defined(_KCC)

--- a/src/db/block.h
+++ b/src/db/block.h
@@ -67,14 +67,14 @@ public:
     {
         return mBlockNum;
     }
-    int8* GetData()
+    int8_t* GetData()
     {
         return mpData;
     }
 
     bool AssertValid() const;
     // this asserts and returns false if the guard bytes have been corrupted
-    bool IsValidAddr(int8* pAddr) const;
+    bool IsValidAddr(int8_t* pAddr) const;
     // returns true if pAddr falls within mpData
 protected:
     enum
@@ -84,9 +84,9 @@ protected:
     }; // odd, non-zero value for debugging
 
     // guardMin and guardMax are used to detect bad writes
-    uint8 mGuardMin[NUM_GUARD_BLOCKS];
-    int8  mpData[SIZE];
-    uint8 mGuardMax[NUM_GUARD_BLOCKS];
+    uint8_t mGuardMin[NUM_GUARD_BLOCKS];
+    int8_t  mpData[SIZE];
+    uint8_t mGuardMax[NUM_GUARD_BLOCKS];
     bool  mbDirty;
     int   mBlockNum;
 };
@@ -107,8 +107,8 @@ template<int SIZE> inline cBlock<SIZE>::cBlock() : mbDirty(false), mBlockNum(cBl
     // init guard blocks to dummy value
     for (int i = 0; i < NUM_GUARD_BLOCKS; i++)
     {
-        mGuardMin[i] = (uint8)GUARD_BLOCK_VAL;
-        mGuardMax[i] = (uint8)GUARD_BLOCK_VAL;
+        mGuardMin[i] = (uint8_t)GUARD_BLOCK_VAL;
+        mGuardMax[i] = (uint8_t)GUARD_BLOCK_VAL;
     }
 
     // zero out memory
@@ -123,7 +123,7 @@ template<int SIZE> inline bool cBlock<SIZE>::AssertValid() const
     // determine if guard bites have been accidentally overwritten
     for (int i = 0; i < NUM_GUARD_BLOCKS; i++)
     {
-        if ((mGuardMin[i] != (uint8)GUARD_BLOCK_VAL) || (mGuardMax[i] != (uint8)GUARD_BLOCK_VAL))
+        if ((mGuardMin[i] != (uint8_t)GUARD_BLOCK_VAL) || (mGuardMax[i] != (uint8_t)GUARD_BLOCK_VAL))
         {
             ASSERT(false);
             return false;
@@ -133,7 +133,7 @@ template<int SIZE> inline bool cBlock<SIZE>::AssertValid() const
     return true;
 }
 
-template<int SIZE> inline bool cBlock<SIZE>::IsValidAddr(int8* pAddr) const
+template<int SIZE> inline bool cBlock<SIZE>::IsValidAddr(int8_t* pAddr) const
 {
     return ((pAddr >= &mpData[0]) && (pAddr <= &mpData[SIZE - 1]));
 }
@@ -156,11 +156,11 @@ public:
     {
         cBlock<SIZE>::mBlockNum = blockNum;
     }
-    void SetTimestamp(uint32 timestamp)
+    void SetTimestamp(uint32_t timestamp)
     {
         mTimestamp = timestamp;
     }
-    uint32 GetTimestamp() const
+    uint32_t GetTimestamp() const
     {
         return mTimestamp;
     }
@@ -169,7 +169,7 @@ public:
     void Read(cBidirArchive& arch, int blockNum = INVALID_NUM); //throw( eArchive )
         // if blockNum is INVALID_NUM, then it reads in the current block number
 protected:
-    uint32 mTimestamp;
+    uint32_t mTimestamp;
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/db/blockfile.cpp
+++ b/src/db/blockfile.cpp
@@ -194,7 +194,7 @@ cBlockFile::Block* cBlockFile::GetBlock(int blockNum) //throw (eArchive)
 #endif
     d.TraceNever("\tBlock %d was not in memory; paging it in\n", blockNum);
 
-    uint32                earliestTime = mvPagedBlocks[0].GetTimestamp();
+    uint32_t                earliestTime = mvPagedBlocks[0].GetTimestamp();
     BlockVector::iterator it           = mvPagedBlocks.begin();
     BlockVector::iterator earliestIter = it;
     ++it; // since we don't want to check the first one

--- a/src/db/blockfile.cpp
+++ b/src/db/blockfile.cpp
@@ -194,7 +194,7 @@ cBlockFile::Block* cBlockFile::GetBlock(int blockNum) //throw (eArchive)
 #endif
     d.TraceNever("\tBlock %d was not in memory; paging it in\n", blockNum);
 
-    uint32_t                earliestTime = mvPagedBlocks[0].GetTimestamp();
+    uint32_t              earliestTime = mvPagedBlocks[0].GetTimestamp();
     BlockVector::iterator it           = mvPagedBlocks.begin();
     BlockVector::iterator earliestIter = it;
     ++it; // since we don't want to check the first one

--- a/src/db/blockfile.h
+++ b/src/db/blockfile.h
@@ -113,7 +113,7 @@ private:
 
     int            mNumPages;
     int            mNumBlocks; // the total number of blocks in the archive.
-    uint32         mTimer;     // keeps track of the current "time"
+    uint32_t         mTimer;     // keeps track of the current "time"
     cBidirArchive* mpArchive;  // note: I always own the deletion of the archive
     BlockVector    mvPagedBlocks;
 

--- a/src/db/blockfile.h
+++ b/src/db/blockfile.h
@@ -113,7 +113,7 @@ private:
 
     int            mNumPages;
     int            mNumBlocks; // the total number of blocks in the archive.
-    uint32_t         mTimer;     // keeps track of the current "time"
+    uint32_t       mTimer;     // keeps track of the current "time"
     cBidirArchive* mpArchive;  // note: I always own the deletion of the archive
     BlockVector    mvPagedBlocks;
 

--- a/src/db/blockrecordarray.cpp
+++ b/src/db/blockrecordarray.cpp
@@ -52,9 +52,9 @@ inline cBlockRecordArray::tIndexArray& util_GetIndexArray(cBlockFile::Block* pBl
 //      is stored in tRecordIndex) return a pointer to memory inside the block
 //      that corresponds to the given offset
 ///////////////////////////////////////////////////////////////////////////////
-inline int8* util_OffsetToAddr(cBlockFile::Block* pBlock, int offset)
+inline int8_t* util_OffsetToAddr(cBlockFile::Block* pBlock, int offset)
 {
-    return (pBlock->GetData() + (cBlockFile::BLOCK_SIZE - offset));
+    return reinterpret_cast<int8_t*>((pBlock->GetData() + (cBlockFile::BLOCK_SIZE - offset)));
 }
 
 
@@ -228,7 +228,7 @@ bool cBlockRecordArray::IsItemValid(int index) const //throw (eArchive)
 ///////////////////////////////////////////////////////////////////////////////
 // AddItem
 ///////////////////////////////////////////////////////////////////////////////
-int cBlockRecordArray::AddItem(int8* pData, int dataSize, int mainIndex) //throw (eArchive)
+int cBlockRecordArray::AddItem(int8_t* pData, int dataSize, int mainIndex) //throw (eArchive)
 {
     // make ourselves initialized, if we are not right now...
     //
@@ -290,7 +290,7 @@ int cBlockRecordArray::AddItem(int8* pData, int dataSize, int mainIndex) //throw
         // we are going to have to shift up the data that is above us...
         //
         int   topOffset = indexArray.maRecordIndex[GetNumItems() - 1].GetOffset();
-        int8* pTop      = util_OffsetToAddr(pBlock, topOffset);
+        int8_t* pTop    = util_OffsetToAddr(pBlock, topOffset);
         int   amtToMove = topOffset - prevOffset;
         ASSERT(amtToMove >= 0);
 
@@ -385,7 +385,7 @@ void cBlockRecordArray::DeleteItem(int index) //throw (eArchive)
         {
             distToShift -= indexArray.maRecordIndex[index - 1].GetOffset();
         }
-        int8* pSrc = util_OffsetToAddr(pBlock, indexArray.maRecordIndex[GetNumItems() - 1].GetOffset());
+        int8_t* pSrc = util_OffsetToAddr(pBlock, indexArray.maRecordIndex[GetNumItems() - 1].GetOffset());
         //
         // copy the data..
         //
@@ -424,7 +424,7 @@ void cBlockRecordArray::DeleteItem(int index) //throw (eArchive)
 ///////////////////////////////////////////////////////////////////////////////
 // GetDataForReading
 ///////////////////////////////////////////////////////////////////////////////
-int8* cBlockRecordArray::GetDataForReading(int index, int32& dataSize) //throw (eArchive)
+int8_t* cBlockRecordArray::GetDataForReading(int index, int32_t& dataSize) //throw (eArchive)
 {
     // make ourselves initialized, if we are not right now...
     //
@@ -457,7 +457,7 @@ int8* cBlockRecordArray::GetDataForReading(int index, int32& dataSize) //throw (
 ///////////////////////////////////////////////////////////////////////////////
 // GetDataForWriting
 ///////////////////////////////////////////////////////////////////////////////
-int8* cBlockRecordArray::GetDataForWriting(int index, int32& dataSize) //throw (eArchive)
+int8_t* cBlockRecordArray::GetDataForWriting(int index, int32_t& dataSize) //throw (eArchive)
 {
     // make ourselves initialized, if we are not right now...
     //
@@ -545,7 +545,7 @@ bool cBlockRecordArray::IsClassValid() const
         //
         // make sure the final offset is less than the highest record index offset.
         //
-        BRA_ASSERT((int8*)&array.maRecordIndex[i] < util_OffsetToAddr(pBlock, prevOff));
+        BRA_ASSERT((int8_t*)&array.maRecordIndex[i] < util_OffsetToAddr(pBlock, prevOff));
         //
         // TODO -- is there anything else that is worth checking?
     }

--- a/src/db/blockrecordarray.h
+++ b/src/db/blockrecordarray.h
@@ -80,18 +80,18 @@ public:
     //-------------------------------------------------------------------------------------
     // Data Manipulation
     //-------------------------------------------------------------------------------------
-    int AddItem(int8* pData, int dataSize, int mainIndex); //throw (eArchive)
+    int AddItem(int8_t* pData, int dataSize, int mainIndex); //throw (eArchive)
         // inserts the given item into the array; returns the index that it was inserted into.
         // this asserts that there is room for the new element, and updates the avail. space and
         // max index as necessary.
     void DeleteItem(int index); //throw (eArchive)
         // deletes the specified item; this asserts that the index is valid, and updates the avail.
         // space and max index as necessary.
-    int8* GetDataForReading(int index, int32& dataSize); //throw (eArchive)
+    int8_t* GetDataForReading(int index, int32_t& dataSize); //throw (eArchive)
         // returns a pointer to the named data. This method will assert that the address is
         // valid. The data pointer returned is guarenteed to be valid only until the next
         // method call into this class.
-    int8* GetDataForWriting(int index, int32& dataSize); //throw (eArchive)
+    int8_t* GetDataForWriting(int index, int32_t& dataSize); //throw (eArchive)
         // this is the same as the previous function, except the dirty bit for the page is also set
     bool IsItemValid(int index) const; //throw (eArchive)
         // returns true if the given index has a valid value.
@@ -125,24 +125,24 @@ public:
     struct tRecordIndex
     {
     private:
-        int32 mOffset;    // offset from the end of the block that my data is at; offset 1 is the last byte in the block
-        int32 mMainIndex; // my main array index
+        int32_t mOffset;    // offset from the end of the block that my data is at; offset 1 is the last byte in the block
+        int32_t mMainIndex; // my main array index
     public:
         // byte order safe access methods...
         //
-        void SetOffset(int32 off)
+        void SetOffset(int32_t off)
         {
             mOffset = tw_htonl(off);
         }
-        int32 GetOffset()
+        int32_t GetOffset()
         {
             return tw_ntohl(mOffset);
         }
-        void SetMainIndex(int32 idx)
+        void SetMainIndex(int32_t idx)
         {
             mMainIndex = tw_htonl(idx);
         }
-        int32 GetMainIndex()
+        int32_t GetMainIndex()
         {
             return tw_ntohl(mMainIndex);
         }
@@ -153,25 +153,25 @@ public:
     struct tHeader
     {
     private:
-        int32 mSpaceAvailable;
-        int32 mNumItems;
+        int32_t mSpaceAvailable;
+        int32_t mNumItems;
 
     public:
         // byte order safe access methods...
         //
-        void SetSpaceAvail(int32 sa)
+        void SetSpaceAvail(int32_t sa)
         {
             mSpaceAvailable = tw_htonl(sa);
         }
-        int32 GetSpaceAvail()
+        int32_t GetSpaceAvail()
         {
             return tw_ntohl(mSpaceAvailable);
         }
-        void SetNumItems(int32 ni)
+        void SetNumItems(int32_t ni)
         {
             mNumItems = tw_htonl(ni);
         }
-        int32 GetNumItems()
+        int32_t GetNumItems()
         {
             return tw_ntohl(mNumItems);
         }
@@ -179,7 +179,7 @@ public:
 
     enum
     {
-        MAX_RECORDS = cBlockFile::BLOCK_SIZE / (sizeof(tRecordIndex) + sizeof(uint32)),
+        MAX_RECORDS = cBlockFile::BLOCK_SIZE / (sizeof(tRecordIndex) + sizeof(uint32_t)),
         // MAX_RECORDS signifies the maximum number of records that can be stored in a single block.
         // It is rationalized like this: each used record needs a tRecordIndex plus an extra uint32
         // as a minimum storage requirement (even though it is ok to have a record that is filled in

--- a/src/db/blockrecordfile.cpp
+++ b/src/db/blockrecordfile.cpp
@@ -150,7 +150,7 @@ void cBlockRecordFile::Flush() //throw (eArchive)
 ///////////////////////////////////////////////////////////////////////////////
 // AddItem
 ///////////////////////////////////////////////////////////////////////////////
-cBlockRecordFile::tAddr cBlockRecordFile::AddItem(int8* pData, int dataSize) //throw (eArchive)
+cBlockRecordFile::tAddr cBlockRecordFile::AddItem(int8_t* pData, int dataSize) //throw (eArchive)
 {
     ASSERT(mbOpen);
 #ifdef _BLOCKFILE_DEBUG
@@ -224,7 +224,7 @@ bool cBlockRecordFile::IsValidAddr(cBlockRecordFile::tAddr addr) //throw (eArchi
 ///////////////////////////////////////////////////////////////////////////////
 // GetDataForReading
 ///////////////////////////////////////////////////////////////////////////////
-int8* cBlockRecordFile::GetDataForReading(cBlockRecordFile::tAddr dataAddr, int32& dataSize) //throw (eArchive)
+int8_t* cBlockRecordFile::GetDataForReading(cBlockRecordFile::tAddr dataAddr, int32_t& dataSize) //throw (eArchive)
 {
     ASSERT(mbOpen);
     ASSERT(IsValidAddr(dataAddr));
@@ -238,7 +238,7 @@ int8* cBlockRecordFile::GetDataForReading(cBlockRecordFile::tAddr dataAddr, int3
 ///////////////////////////////////////////////////////////////////////////////
 // GetDataForWriting
 ///////////////////////////////////////////////////////////////////////////////
-int8* cBlockRecordFile::GetDataForWriting(cBlockRecordFile::tAddr dataAddr, int32& dataSize) //throw (eArchive)
+int8_t* cBlockRecordFile::GetDataForWriting(cBlockRecordFile::tAddr dataAddr, int32_t& dataSize) //throw (eArchive)
 {
     ASSERT(mbOpen);
     ASSERT(IsValidAddr(dataAddr));
@@ -252,7 +252,7 @@ int8* cBlockRecordFile::GetDataForWriting(cBlockRecordFile::tAddr dataAddr, int3
 ///////////////////////////////////////////////////////////////////////////////
 // FindRoomForData
 ///////////////////////////////////////////////////////////////////////////////
-int cBlockRecordFile::FindRoomForData(int32 dataSize) //throw (eArchive)
+int cBlockRecordFile::FindRoomForData(int32_t dataSize) //throw (eArchive)
 {
     ASSERT((dataSize > 0) && (dataSize <= cBlockRecordArray::MAX_DATA_SIZE));
     ASSERT(mbOpen);

--- a/src/db/blockrecordfile.h
+++ b/src/db/blockrecordfile.h
@@ -74,10 +74,10 @@ public:
     //-------------------------------------------------------------------------
     struct tAddr
     {
-        int32 mBlockNum;
-        int32 mIndex;
+        int32_t mBlockNum;
+        int32_t mIndex;
 
-        tAddr(int32 block = -1, int32 addr = -1) : mBlockNum(block), mIndex(addr)
+        tAddr(int32_t block = -1, int32_t addr = -1) : mBlockNum(block), mIndex(addr)
         {
         }
     };
@@ -85,7 +85,7 @@ public:
     //-------------------------------------------------------------------------
     // Adding and Removing Data
     //-------------------------------------------------------------------------
-    tAddr AddItem(int8* pData, int dataSize); //throw (eArchive)
+    tAddr AddItem(int8_t* pData, int dataSize); //throw (eArchive)
         // adds the given data to the file, growing it as necessary. Return value
         // can be used in the future to retrieve the data
     void RemoveItem(tAddr dataAddr); //throw (eArchive)
@@ -99,11 +99,11 @@ public:
     //-------------------------------------------------------------------------
     bool IsValidAddr(tAddr addr); //throw (eArchive)
         // returns true if the given address points to valid data
-    int8* GetDataForReading(tAddr dataAddr, int32& dataSize); //throw (eArchive)
+    int8_t* GetDataForReading(tAddr dataAddr, int32_t& dataSize); //throw (eArchive)
         // returns a pointer to the named data. This method will assert that the address is
         // valid. The data pointer returned is guarenteed to be valid only until the next
         // method call into this class.
-    int8* GetDataForWriting(tAddr dataAddr, int32& dataSize); //throw (eArchive)
+    int8_t* GetDataForWriting(tAddr dataAddr, int32_t& dataSize); //throw (eArchive)
         // this is the same as the previous function, except the dirty bit for the page is also set
 
     cBidirArchive* GetArchive()
@@ -130,7 +130,7 @@ protected:
     }
 
 private:
-    int32      mLastAddedTo; // optimization that keeps track of last block added to
+    int32_t      mLastAddedTo; // optimization that keeps track of last block added to
     bool       mbOpen;       // are we currently associated with a file?
     cBlockFile mBlockFile;
     BlockArray mvBlocks;
@@ -138,7 +138,7 @@ private:
     cBlockRecordFile(const cBlockRecordFile& rhs); //not impl
     void operator=(const cBlockRecordFile& rhs);   //not impl
 
-    int FindRoomForData(int32 dataSize); //throw (eArchive)
+    int FindRoomForData(int32_t dataSize); //throw (eArchive)
         // searches through all the blocks, starting with mLastAddedTo, looking
         // for one with dataSize free space. This asserts that the size is valid
         // for storage in a block

--- a/src/db/hierdatabase.cpp
+++ b/src/db/hierdatabase.cpp
@@ -64,8 +64,8 @@ static inline void util_ThrowIfNull(const cHierAddr& addr, const TSTRING& contex
 ///////////////////////////////////////////////////////////////////////////////
 static void util_ReadObject(cHierDatabase* pDb, cHierNode* pNode, const cHierAddr& addr)
 {
-    int32 dataSize;
-    int8* pData = pDb->GetDataForReading(cBlockRecordFile::tAddr(addr.mBlockNum, addr.mIndex), dataSize);
+    int32_t dataSize;
+    int8_t* pData = pDb->GetDataForReading(cBlockRecordFile::tAddr(addr.mBlockNum, addr.mIndex), dataSize);
     //
     // make sure we aren't trying to read a null object
     //
@@ -96,8 +96,8 @@ static cHierAddr util_WriteObject(cHierDatabase* pDb, cHierNode* pNode)
 ///////////////////////////////////////////////////////////////////////////////
 static void util_RewriteObject(cHierDatabase* pDb, cHierNode* pNode, const cHierAddr& addr)
 {
-    int32 dataSize;
-    int8* pData = pDb->GetDataForWriting(cBlockRecordFile::tAddr(addr.mBlockNum, addr.mIndex), dataSize);
+    int32_t dataSize;
+    int8_t* pData = pDb->GetDataForWriting(cBlockRecordFile::tAddr(addr.mBlockNum, addr.mIndex), dataSize);
 
     util_ThrowIfNull(addr, _T("util_RewriteObject"));
 
@@ -557,7 +557,7 @@ void cHierDatabaseIter::CreateEntry(const TSTRING& name) //throw (eArchive, eHie
 ///////////////////////////////////////////////////////////////////////////////
 // GetData
 ///////////////////////////////////////////////////////////////////////////////
-int8* cHierDatabaseIter::GetData(int32& length) const //throw (eArchive, eHierDatabase)
+int8_t* cHierDatabaseIter::GetData(int32_t& length) const //throw (eArchive, eHierDatabase)
 {
     ASSERT(HasData());
     if (!HasData())
@@ -587,7 +587,7 @@ bool cHierDatabaseIter::HasData() const
 ///////////////////////////////////////////////////////////////////////////////
 // SetData
 ///////////////////////////////////////////////////////////////////////////////
-void cHierDatabaseIter::SetData(int8* pData, int32 length) //throw (eArchive, eHierDatabase)
+void cHierDatabaseIter::SetData(int8_t* pData, int32_t length) //throw (eArchive, eHierDatabase)
 {
     ASSERT(!Done());
     ASSERT(!HasData());

--- a/src/db/hierdatabase.h
+++ b/src/db/hierdatabase.h
@@ -184,12 +184,12 @@ public:
     //
     // getting and setting the data associated with a given entry
     //
-    int8* GetData(int32& length) const; //throw (eArchive, eHierDatabase)
+    int8_t* GetData(int32_t& length) const; //throw (eArchive, eHierDatabase)
         // returns the data associated with the current entry; this asserts that the iterator is
         // not done and the current entry has data associated with it
     bool HasData() const;
     // returns true if the current entry has data
-    void SetData(int8* pData, int32 length); //throw (eArchive, eHierDatabase)
+    void SetData(int8_t* pData, int32_t length); //throw (eArchive, eHierDatabase)
     void RemoveData();                       //throw (eArchive, eHierDatabase)
         // removes the data associated with the current entry; this asserts that the current
         // entry actually _has_ data

--- a/src/db/hierdbnode.h
+++ b/src/db/hierdbnode.h
@@ -75,12 +75,12 @@ public:
     {
     }
 
-    int32 mType;
+    int32_t mType;
 
     /////////////////////////////////////////
     // methods to override
     /////////////////////////////////////////
-    virtual int32 CalcArchiveSize() const
+    virtual int32_t CalcArchiveSize() const
     {
         return (sizeof(mType));
     }
@@ -113,10 +113,10 @@ public:
 class cHierAddr
 {
 public:
-    int32 mBlockNum;
-    int32 mIndex;
+    int32_t mBlockNum;
+    int32_t mIndex;
 
-    cHierAddr(int32 block = -1, int32 index = -1) : mBlockNum(block), mIndex(index)
+    cHierAddr(int32_t block = -1, int32_t index = -1) : mBlockNum(block), mIndex(index)
     {
     }
 
@@ -134,7 +134,7 @@ public:
     /////////////////////////////////////////////////
     // serialization methods
     /////////////////////////////////////////////////
-    int32 CalcArchiveSize() const
+    int32_t CalcArchiveSize() const
     {
         return (sizeof(mBlockNum) + sizeof(mIndex));
     }
@@ -169,7 +169,7 @@ public:
     /////////////////////////////////////////////////
     // serialization methods
     /////////////////////////////////////////////////
-    virtual int32 CalcArchiveSize() const
+    virtual int32_t CalcArchiveSize() const
     {
         return (cHierNode::CalcArchiveSize() + mChild.CalcArchiveSize());
     }
@@ -193,7 +193,7 @@ public:
             throw eArchiveFormat(_T("Invalid type encountered; expected ROOT node"));
         }
         mChild.Read(arch);
-        int32 cs;
+        int32_t cs;
         arch.ReadInt32(cs);
         mbCaseSensitive = cs ? true : false;
         TSTRING dc;
@@ -226,7 +226,7 @@ public:
     /////////////////////////////////////////////////
     // serialization methods
     /////////////////////////////////////////////////
-    virtual int32 CalcArchiveSize() const
+    virtual int32_t CalcArchiveSize() const
     {
         return (cHierNode::CalcArchiveSize() + mChild.CalcArchiveSize() + mData.CalcArchiveSize() +
                 cArchive::GetStorageSize(mName) + mNext.CalcArchiveSize());
@@ -274,7 +274,7 @@ public:
     /////////////////////////////////////////////////
     // serialization methods
     /////////////////////////////////////////////////
-    virtual int32 CalcArchiveSize() const
+    virtual int32_t CalcArchiveSize() const
     {
         return (cHierNode::CalcArchiveSize() + mParent.CalcArchiveSize() + mArray.CalcArchiveSize());
     }

--- a/src/fco/fco.h
+++ b/src/fco/fco.h
@@ -113,7 +113,7 @@ public:
     // by the FCO and is only guarenteed to be valid through the life of the
     // fco.
 
-    virtual uint32 GetCaps() const = 0;
+    virtual uint32_t GetCaps() const = 0;
     // returns a bitmask that indicates properties that this object has.
     // see the enum below for what the caps can contain
 
@@ -200,8 +200,8 @@ public:
     virtual void Clear() = 0;
     // clears out all the elements from the set
 
-    virtual bool IsEmpty() const = 0;
-    virtual int  Size() const    = 0;
+    virtual bool      IsEmpty() const = 0;
+    virtual int       Size()    const = 0;
 
     virtual void TraceContents(int debugLevel = -1) const
     {

--- a/src/fco/fcocompare.cpp
+++ b/src/fco/fcocompare.cpp
@@ -57,7 +57,7 @@ cFCOCompare::~cFCOCompare()
 ///////////////////////////////////////////////////////////////////////////////
 // Compare
 ///////////////////////////////////////////////////////////////////////////////
-uint32 cFCOCompare::Compare(const iFCO* pFco1, const iFCO* pFco2)
+uint32_t cFCOCompare::Compare(const iFCO* pFco1, const iFCO* pFco2)
 {
     ASSERT(pFco1 != 0);
     ASSERT(pFco2 != 0);
@@ -74,7 +74,7 @@ uint32 cFCOCompare::Compare(const iFCO* pFco1, const iFCO* pFco2)
     const cFCOPropVector& v1  = pFco1->GetPropSet()->GetValidVector();
     const cFCOPropVector& v2  = pFco2->GetPropSet()->GetValidVector();
 
-    uint32 result = 0;
+    uint32_t result = 0;
 
     mInvalidProps.SetSize(v1.GetSize());
     mUnequalProps.SetSize(v1.GetSize());

--- a/src/fco/fcocompare.h
+++ b/src/fco/fcocompare.h
@@ -61,7 +61,7 @@ public:
     // gets and sets the property vector that indicates what properties the
     // object will consider in the comparisons.
 
-    uint32 Compare(const iFCO* pFco1, const iFCO* pFco2);
+    uint32_t Compare(const iFCO* pFco1, const iFCO* pFco2);
     // compares fco1 and fco2, only considering the properties specified set with
     // SetPropsToCmp(). The result of the comparison is a bitmask that is currently either
     // EQUAL or a combination of PROPS_NOT_ALL_VALID and PROPS_UNEQUAL. You can discover which

--- a/src/fco/fcodatasourceiterimpl.h
+++ b/src/fco/fcodatasourceiterimpl.h
@@ -109,7 +109,7 @@ protected:
     cFCOName                mParentName;
     FCOList                 mPeers;
     FCOList::const_iterator mCurPos;
-    uint32                  mFlags;
+    uint32_t                mFlags;
 
     //-------------------------------------------------------------------------
     // helper methods

--- a/src/fco/fcogenre.h
+++ b/src/fco/fcogenre.h
@@ -54,7 +54,7 @@
 class cGenre
 {
 public:
-    typedef uint32 Genre;
+    typedef uint32_t Genre;
 
 
     //-----------------------------------------

--- a/src/fco/fconame.cpp
+++ b/src/fco/fconame.cpp
@@ -382,7 +382,7 @@ cFCOName::Relationship cFCOName::GetRelationship(const cFCOName& rhs) const
 // TODO -- serialize the hash table and nodes instead of reading and writing
 //      as a string
 ///////////////////////////////////////////////////////////////////////////////
-void cFCOName::Read(iSerializer* pSerializer, int32 version)
+void cFCOName::Read(iSerializer* pSerializer, int32_t version)
 {
     if (version > Version())
         ThrowAndAssert(eSerializerVersionMismatch(_T("FCO Name Read")));
@@ -390,7 +390,7 @@ void cFCOName::Read(iSerializer* pSerializer, int32 version)
     TSTRING str;
     pSerializer->ReadString(str);
 
-    int16 dummy = 0;
+    int16_t dummy = 0;
 
     // serialize the delimiter
     pSerializer->ReadInt16(dummy); // delimiter, but it's always '/' anyway in OST.
@@ -421,7 +421,7 @@ void cFCOName::Write(iSerializer* pSerializer) const
     // serialize the delimiter
     unsigned short wc = (unsigned short)'/';
     pSerializer->WriteInt16(wc);
-    pSerializer->WriteInt16(mbCaseSensitive ? (int16)1 : (int16)0);
+    pSerializer->WriteInt16(mbCaseSensitive ? (int16_t)1 : (int16_t)0);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/fco/fconame.h
+++ b/src/fco/fconame.h
@@ -123,7 +123,7 @@ public:
     // returns the relationship of _this_ name to the one passed in (ie -- if REL_BELOW is returned,
     // this fco name is below the one passed in)
 
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 
     //////////////////////////////////

--- a/src/fco/fcopropimpl.cpp
+++ b/src/fco/fcopropimpl.cpp
@@ -135,10 +135,10 @@ iFCOProp::CmpResult cFCOPropInt32::Compare(const iFCOProp* rhs, iFCOProp::Op op)
     return DefaultCompare(this, rhs, op);
 }
 
-void cFCOPropInt32::Read(iSerializer* pSerializer, int32 version)
+void cFCOPropInt32::Read(iSerializer* pSerializer, int32_t version)
 {
     if (version > 0)
-        ThrowAndAssert(eSerializerVersionMismatch(_T("Int32 Property Read")));
+        ThrowAndAssert(eSerializerVersionMismatch(_T("int32_t Property Read")));
 
     pSerializer->ReadInt32(mValue);
 }
@@ -166,7 +166,7 @@ TSTRING cFCOPropInt64::AsString() const
     //
     TOSTRINGSTREAM ostr;
     ostr.imbue(std::locale::classic());
-    ostr << (int32)mValue;
+    ostr << (int32_t)mValue;  // TODO: remove this cast where possible
     return TSTRING(ostr.str());
 }
 
@@ -175,10 +175,10 @@ iFCOProp::CmpResult cFCOPropInt64::Compare(const iFCOProp* rhs, iFCOProp::Op op)
     return DefaultCompare(this, rhs, op);
 }
 
-void cFCOPropInt64::Read(iSerializer* pSerializer, int32 version)
+void cFCOPropInt64::Read(iSerializer* pSerializer, int32_t version)
 {
     if (version > 0)
-        ThrowAndAssert(eSerializerVersionMismatch(_T("Int64 Property Read")));
+        ThrowAndAssert(eSerializerVersionMismatch(_T("int64_t Property Read")));
 
     pSerializer->ReadInt64(mValue);
 }
@@ -206,7 +206,7 @@ TSTRING cFCOPropUint64::AsString() const
     //
     TOSTRINGSTREAM ostr;
     ostr.imbue(std::locale::classic());
-    ostr << (int32)mValue;
+    ostr << (int32_t)mValue; // TODO: remove this cast where possible
     return TSTRING(ostr.str());
 }
 
@@ -215,12 +215,12 @@ iFCOProp::CmpResult cFCOPropUint64::Compare(const iFCOProp* rhs, iFCOProp::Op op
     return DefaultCompare(this, rhs, op);
 }
 
-void cFCOPropUint64::Read(iSerializer* pSerializer, int32 version)
+void cFCOPropUint64::Read(iSerializer* pSerializer, int32_t version)
 {
     if (version > 0)
-        ThrowAndAssert(eSerializerVersionMismatch(_T("uint64 Property Read")));
+        ThrowAndAssert(eSerializerVersionMismatch(_T("uint64_t Property Read")));
 
-    pSerializer->ReadInt64((int64&)mValue);
+    pSerializer->ReadInt64((int64_t&)mValue);
 }
 
 void cFCOPropUint64::Write(iSerializer* pSerializer) const
@@ -250,7 +250,7 @@ iFCOProp::CmpResult cFCOPropTSTRING::Compare(const iFCOProp* rhs, iFCOProp::Op o
     return DefaultCompare(this, rhs, op);
 }
 
-void cFCOPropTSTRING::Read(iSerializer* pSerializer, int32 version)
+void cFCOPropTSTRING::Read(iSerializer* pSerializer, int32_t version)
 {
     if (version > 0)
         ThrowAndAssert(eSerializerVersionMismatch(_T("String Property Read")));

--- a/src/fco/fcopropimpl.h
+++ b/src/fco/fcopropimpl.h
@@ -65,7 +65,7 @@ public:                           \
 class cFCOPropInt32 : public iFCOProp
 {
 public:
-    PROP_DATA(int32)            // see macro above
+    PROP_DATA(int32_t)            // see macro above
     DECLARE_TYPEDSERIALIZABLE() // type information
 
     cFCOPropInt32() : mValue(0)
@@ -81,14 +81,14 @@ public:
     virtual void      Copy(const iFCOProp* rhs);
 
     // iSerializable interface
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 };
 
 class cFCOPropInt64 : public iFCOProp
 {
 public:
-    PROP_DATA(int64)            // see macro above
+    PROP_DATA(int64_t)            // see macro above
     DECLARE_TYPEDSERIALIZABLE() // type information
 
     cFCOPropInt64() : mValue(0)
@@ -104,14 +104,14 @@ public:
     virtual void      Copy(const iFCOProp* rhs);
 
     // iSerializable interface
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 };
 
 class cFCOPropUint64 : public iFCOProp
 {
 public:
-    PROP_DATA(uint64)           // see macro above
+    PROP_DATA(uint64_t)           // see macro above
     DECLARE_TYPEDSERIALIZABLE() // type information
 
     cFCOPropUint64() : mValue(0)
@@ -127,7 +127,7 @@ public:
     virtual void      Copy(const iFCOProp* rhs);
 
     // iSerializable interface
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 };
 
@@ -151,7 +151,7 @@ public:
     virtual void      Copy(const iFCOProp* rhs);
 
     // iSerializable interface
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 };
 

--- a/src/fco/fcopropvector.cpp
+++ b/src/fco/fcopropvector.cpp
@@ -39,7 +39,7 @@
 #include "core/debug.h"
 #include "core/errorutil.h"
 
-int cFCOPropVector::msBitlength(sizeof(uint32) * 8);
+int cFCOPropVector::msBitlength(sizeof(uint32_t) * 8);
 //msBitlength is common to all objects of class.
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -71,7 +71,7 @@ cFCOPropVector::cFCOPropVector(const cFCOPropVector& rhs) : iSerializable()
     mMask = rhs.mMask;
     if (rhs.mpBuf != NULL)
     {
-        mpBuf  = new std::vector<uint32>;
+        mpBuf  = new std::vector<uint32_t>;
         *mpBuf = *(rhs.mpBuf);
     }
     else
@@ -122,7 +122,7 @@ cFCOPropVector& cFCOPropVector::operator=(const cFCOPropVector& rhs)
             *mpBuf = *(rhs.mpBuf);
         else if ((rhs.mpBuf != NULL) && (mpBuf == NULL))
         {
-            mpBuf  = new std::vector<uint32>;
+            mpBuf  = new std::vector<uint32_t>;
             *mpBuf = *(rhs.mpBuf);
         }
         else if ((rhs.mpBuf == NULL) && (mpBuf != NULL))
@@ -254,7 +254,7 @@ int cFCOPropVector::SetSize(int max)
     }
     else if ((mpBuf == NULL) && (max > msBitlength))
     {
-        mpBuf = new std::vector<uint32>;
+        mpBuf = new std::vector<uint32_t>;
         (*mpBuf).resize(((max / msBitlength) + 1), 0);
         (*mpBuf)[0]  = mMask;
         return mSize = ((*mpBuf).capacity() * msBitlength);
@@ -367,8 +367,8 @@ bool cFCOPropVector::isExtended(void) const
             return false;
         else
         {
-            uint32 sum = 0;
-            for (uint32 i = (*mpBuf).size() - 1; i >= 2; i--)
+            uint32_t sum = 0;
+            for (uint32_t i = (*mpBuf).size() - 1; i >= 2; i--)
                 sum += ((*mpBuf)[i]);
             return (sum != 0);
         }
@@ -391,12 +391,12 @@ void cFCOPropVector::check(cDebug& d) const
 } //end check
 
 
-void cFCOPropVector::Read(iSerializer* pSerializer, int32 version)
+void cFCOPropVector::Read(iSerializer* pSerializer, int32_t version)
 {
     if (version > 0)
         ThrowAndAssert(eSerializerVersionMismatch(_T("Property Vector Read")));
 
-    int32 newSize;
+    int32_t newSize;
     pSerializer->ReadInt32(newSize);
     ASSERT(newSize > 0);
 
@@ -404,7 +404,7 @@ void cFCOPropVector::Read(iSerializer* pSerializer, int32 version)
 
     if (mpBuf == NULL)
     {
-        int32 mask;
+        int32_t mask;
         pSerializer->ReadInt32(mask);
         mMask = mask;
     }
@@ -412,7 +412,7 @@ void cFCOPropVector::Read(iSerializer* pSerializer, int32 version)
     {
         for (int i = 0; i <= mSize / msBitlength; ++i)
         {
-            int32 mask;
+            int32_t mask;
             pSerializer->ReadInt32(mask);
             (*mpBuf)[i] = mask;
         }

--- a/src/fco/fcopropvector.h
+++ b/src/fco/fcopropvector.h
@@ -86,7 +86,7 @@ public:
     void check(cDebug& d) const;
     // Temp function for testing purposes.  Outputs vector info. TO DO:
     // Get rid of this when it's no longer useful! DA
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
         // iSerializable interface
     void TraceContents(int dl = -1) const;
@@ -96,10 +96,10 @@ private:
     bool isExtended(void) const;
     // Helper function that discerns if an object is using mpBuf beyond [0]
 
-    int                  mSize;
-    static int           msBitlength;
-    uint32               mMask;
-    std::vector<uint32>* mpBuf;
+    int                    mSize;
+    static int             msBitlength;
+    uint32_t               mMask;
+    std::vector<uint32_t>* mpBuf;
 };
 
 #endif //__FCOPROPVECTOR_H

--- a/src/fco/fcosetimpl.cpp
+++ b/src/fco/fcosetimpl.cpp
@@ -178,7 +178,7 @@ void cFCOSetImpl::Insert(iFCO* pFCO)
 ///////////////////////////////////////////////////////////////////////////////
 // AcceptSerializer
 ///////////////////////////////////////////////////////////////////////////////
-void cFCOSetImpl::Read(iSerializer* pSerializer, int32 version)
+void cFCOSetImpl::Read(iSerializer* pSerializer, int32_t version)
 {
     if (version > Version())
         ThrowAndAssert(eSerializerVersionMismatch(_T("FCO Set Read")));
@@ -186,7 +186,7 @@ void cFCOSetImpl::Read(iSerializer* pSerializer, int32 version)
     Clear();
 
     int   i;
-    int32 size;
+    int32_t size;
     pSerializer->ReadInt32(size);
 
     // TODO -- don't assert; throw an exception or noop -- mdb

--- a/src/fco/fcosetimpl.h
+++ b/src/fco/fcosetimpl.h
@@ -72,7 +72,7 @@ public:
     virtual void TraceContents(int dl = -1) const;
 
     // iSerializable interface
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 private:
     void ReturnIter(const cFCOIterImpl* pIter) const;

--- a/src/fco/fcospecattr.cpp
+++ b/src/fco/fcospecattr.cpp
@@ -42,12 +42,12 @@ IMPLEMENT_SERREFCOUNT(cFCOSpecAttr, _T("cFCOSpecAttr"), 0, 1)
 ///////////////////////////////////////////////////////////////////////////////
 // Read
 ///////////////////////////////////////////////////////////////////////////////
-void cFCOSpecAttr::Read(iSerializer* pSerializer, int32 version)
+void cFCOSpecAttr::Read(iSerializer* pSerializer, int32_t version)
 {
     pSerializer->ReadString(mName);
     pSerializer->ReadInt32(mSeverity);
 
-    int32   size;
+    int32_t   size;
     TSTRING str;
     pSerializer->ReadInt32(size);
     mEmailAddrs.clear();

--- a/src/fco/fcospecattr.cpp
+++ b/src/fco/fcospecattr.cpp
@@ -47,7 +47,7 @@ void cFCOSpecAttr::Read(iSerializer* pSerializer, int32_t version)
     pSerializer->ReadString(mName);
     pSerializer->ReadInt32(mSeverity);
 
-    int32_t   size;
+    int32_t size;
     TSTRING str;
     pSerializer->ReadInt32(size);
     mEmailAddrs.clear();

--- a/src/fco/fcospecattr.h
+++ b/src/fco/fcospecattr.h
@@ -63,15 +63,15 @@ public:
     const TSTRING& GetName() const;
     void           SetName(const TSTRING& name);
 
-    int32 GetSeverity() const;
-    void  SetSeverity(int32 s);
+    int32_t GetSeverity() const;
+    void    SetSeverity(int32_t s);
 
     int  GetNumEmail() const;
     void AddEmail(const TSTRING& str);
     // adds an email address for report notification. This class makes no attempt
     // to catch and prune identical entries in the email list.
 
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 
     void TraceContents(int dl = -1) const;
@@ -85,7 +85,7 @@ private:
 
     std::list<TSTRING> mEmailAddrs; // the email addresses of people to be notified
     TSTRING            mName;       // the name of the spec
-    int32              mSeverity;   // the severity level
+    int32_t            mSeverity;   // the severity level
 
     friend class cFCOSpecAttrEmailIter;
 };
@@ -128,11 +128,11 @@ inline void cFCOSpecAttr::SetName(const TSTRING& name)
 {
     mName = name;
 }
-inline int32 cFCOSpecAttr::GetSeverity() const
+inline int32_t cFCOSpecAttr::GetSeverity() const
 {
     return mSeverity;
 }
-inline void cFCOSpecAttr::SetSeverity(int32 s)
+inline void cFCOSpecAttr::SetSeverity(int32_t s)
 {
     mSeverity = s;
 }

--- a/src/fco/fcospechelper.cpp
+++ b/src/fco/fcospechelper.cpp
@@ -46,7 +46,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // Read
 ///////////////////////////////////////////////////////////////////////////////
-void iFCOSpecHelper::Read(iSerializer* pSerializer, int32 version)
+void iFCOSpecHelper::Read(iSerializer* pSerializer, int32_t version)
 {
     // read the start point
     pSerializer->ReadObject(&mStartPoint);
@@ -247,14 +247,14 @@ iFCOSpecHelper* cFCOSpecStopPointSet::Clone() const
 ///////////////////////////////////////////////////////////////////////////////
 // Read
 ///////////////////////////////////////////////////////////////////////////////
-void cFCOSpecStopPointSet::Read(iSerializer* pSerializer, int32 version)
+void cFCOSpecStopPointSet::Read(iSerializer* pSerializer, int32_t version)
 {
     // read the start point
     //pSerializer->ReadObject(&mStartPoint);
     inherited::Read(pSerializer, version);
 
     // read all the stop points
-    int32 size;
+    int32_t size;
     pSerializer->ReadInt32(size);
     ASSERT(size >= 0);
     for (int i = 0; i < size; ++i)
@@ -346,7 +346,7 @@ bool cFCOSpecNoChildren::ShouldStopDescent(const cFCOName& name) const
 ///////////////////////////////////////////////////////////////////////////////
 // Read
 ///////////////////////////////////////////////////////////////////////////////
-void cFCOSpecNoChildren::Read(iSerializer* pSerializer, int32 version)
+void cFCOSpecNoChildren::Read(iSerializer* pSerializer, int32_t version)
 {
     inherited::Read(pSerializer, version);
 }

--- a/src/fco/fcospechelper.h
+++ b/src/fco/fcospechelper.h
@@ -75,7 +75,7 @@ public:
     // encountered. Really, ContainsFCO() could be used to reach the same ends, but
     // this might/should be faster.
 
-    virtual void Read(iSerializer* pSerializer, int32 version = 0);
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0);
     virtual void Write(iSerializer* pSerializer) const;
     // these just serialize the start point.
 
@@ -154,7 +154,7 @@ public:
 
 
     // iSerializable interface
-    virtual void Read(iSerializer* pSerializer, int32 version = 0);
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0);
     virtual void Write(iSerializer* pSerializer) const;
 
     virtual CompareResult Compare(const iFCOSpecHelper* pRhs) const;
@@ -209,7 +209,7 @@ public:
     virtual bool            ContainsFCO(const cFCOName& name) const;
     virtual iFCOSpecHelper* Clone() const;
     virtual bool            ShouldStopDescent(const cFCOName& name) const;
-    virtual void            Read(iSerializer* pSerializer, int32 version = 0);
+    virtual void            Read(iSerializer* pSerializer, int32_t version = 0);
     virtual void            Write(iSerializer* pSerializer) const;
     virtual CompareResult   Compare(const iFCOSpecHelper* pRhs) const;
     virtual void            TraceContents(int dl = -1) const;

--- a/src/fco/fcospecimpl.cpp
+++ b/src/fco/fcospecimpl.cpp
@@ -178,7 +178,7 @@ const iFCOSpecMask* cFCOSpecImpl::GetSpecMask(const iFCO* pFCO) const
 }
 
 
-void cFCOSpecImpl::Read(iSerializer* pSerializer, int32 version)
+void cFCOSpecImpl::Read(iSerializer* pSerializer, int32_t version)
 {
     if (version > Version())
         ThrowAndAssert(eSerializerVersionMismatch(_T("FS Spec Read")));

--- a/src/fco/fcospecimpl.h
+++ b/src/fco/fcospecimpl.h
@@ -91,7 +91,7 @@ public:
     // but it will not delete the current helper when SetHelper() is called.
 
     // iSerializable interface
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 
 

--- a/src/fco/fcospeclist.cpp
+++ b/src/fco/fcospeclist.cpp
@@ -134,7 +134,7 @@ iFCOSpec* cFCOSpecList::Lookup(iFCOSpec* pSpec) const
     return NULL;
 }
 
-void cFCOSpecList::Read(iSerializer* pSerializer, int32 version)
+void cFCOSpecList::Read(iSerializer* pSerializer, int32_t version)
 {
     if (version > Version())
         ThrowAndAssert(eSerializerVersionMismatch(_T("FCO Spec List")));
@@ -142,7 +142,7 @@ void cFCOSpecList::Read(iSerializer* pSerializer, int32 version)
     Clear();
 
     int   i;
-    int32 size;
+    int32_t size;
     pSerializer->ReadInt32(size);
 
     for (i = 0; i < size; ++i)

--- a/src/fco/fcospeclist.cpp
+++ b/src/fco/fcospeclist.cpp
@@ -103,6 +103,7 @@ void cFCOSpecList::Add(iFCOSpec* pSpec, cFCOSpecAttr* pAttr)
         pAttr = new cFCOSpecAttr;
     else
         pAttr->AddRef();
+        
     for (itr = mCanonicalList.begin();; ++itr)
     {
         if (itr == mCanonicalList.end() || iFCOSpecUtil::FCOSpecLessThan(*pSpec, *itr->first))
@@ -118,18 +119,22 @@ iFCOSpec* cFCOSpecList::Lookup(iFCOSpec* pSpec) const
 {
     std::list<PairType>::iterator itr;
     for (itr = mCanonicalList.begin(); itr != mCanonicalList.end(); ++itr)
+    {
         if (itr->first == pSpec)
         {
             pSpec->AddRef();
             return itr->first;
         }
+    }
 
     for (itr = mCanonicalList.begin(); itr != mCanonicalList.end(); ++itr)
+    {
         if (iFCOSpecUtil::FCOSpecEqual(*pSpec, *itr->first))
         {
             itr->first->AddRef();
             return itr->first;
         }
+    }
 
     return NULL;
 }
@@ -141,11 +146,10 @@ void cFCOSpecList::Read(iSerializer* pSerializer, int32_t version)
 
     Clear();
 
-    int   i;
     int32_t size;
     pSerializer->ReadInt32(size);
 
-    for (i = 0; i < size; ++i)
+    for (int i = 0; i < size; ++i)
     {
         iFCOSpec*     pReadInSpec = static_cast<iFCOSpec*>(pSerializer->ReadObjectDynCreate());
         cFCOSpecAttr* pSpecAttr   = static_cast<cFCOSpecAttr*>(pSerializer->ReadObjectDynCreate());

--- a/src/fco/fcospeclist.h
+++ b/src/fco/fcospeclist.h
@@ -91,7 +91,7 @@ public:
     // object was AddRef()ed
 
     // iSerializable interface
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 
 protected:

--- a/src/fco/fcoundefprop.cpp
+++ b/src/fco/fcoundefprop.cpp
@@ -113,7 +113,7 @@ iFCOProp::CmpResult cFCOUndefinedProp::Compare(const iFCOProp* rhs, iFCOProp::Op
     }
 }
 
-void cFCOUndefinedProp::Read(iSerializer* pSerializer, int32 version)
+void cFCOUndefinedProp::Read(iSerializer* pSerializer, int32_t version)
 {
     ThrowAndAssert(INTERNAL_ERROR("fcoundefprop.cpp"));
 }

--- a/src/fco/fcoundefprop.h
+++ b/src/fco/fcoundefprop.h
@@ -67,7 +67,7 @@ private:
     // don't new or construct these on the stack
 
     // iSerializable interface
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eInternal)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eInternal)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eInternal)
         // These functions should never be called, and they will throw and eInternal if they are.
 };

--- a/src/fco/genreswitcher.cpp
+++ b/src/fco/genreswitcher.cpp
@@ -142,7 +142,7 @@ bool cGenreSwitcher::IsGenreRegistered(cGenre::Genre g)
 
 bool cGenreSwitcher::IsGenreAppropriate(cGenre::Genre g)
 {
-    const uint32 platformMask = cGenre::PLATFORM_MASK_UNIX;
+    const uint32_t platformMask = cGenre::PLATFORM_MASK_UNIX;
     return ((platformMask & g) != 0);
 }
 

--- a/src/fco/signature.cpp
+++ b/src/fco/signature.cpp
@@ -110,7 +110,7 @@ void cArchiveSigGen::CalculateSignatures(cArchive& a)
     uint8_t                   abBuf[iSignature::SUGGESTED_BLOCK_SIZE * 2];
     int                       cbRead;
     container_type::size_type i;
-    uint8_t*                     pBuf = abBuf;
+    uint8_t*                  pBuf = abBuf;
 
     if (s_direct)
     {

--- a/src/fco/signature.cpp
+++ b/src/fco/signature.cpp
@@ -107,7 +107,7 @@ void cArchiveSigGen::AddSig(iSignature* pSig)
 
 void cArchiveSigGen::CalculateSignatures(cArchive& a)
 {
-    uint8_t                      abBuf[iSignature::SUGGESTED_BLOCK_SIZE * 2];
+    uint8_t                   abBuf[iSignature::SUGGESTED_BLOCK_SIZE * 2];
     int                       cbRead;
     container_type::size_type i;
     uint8_t*                     pBuf = abBuf;
@@ -158,9 +158,9 @@ char* btob64(const uint8_t* pcbitvec, char* pcout, int numbits)
 {
     unsigned int val;
     int          offset;
-    uint8*                pcorig = (uint8*)pcout;
+    uint8_t*     pcorig = (uint8_t*)pcout;
 
-    ASSERT(sizeof(uint8) == sizeof(uint8_t)); /* everything breaks otherwise */
+    ASSERT(sizeof(uint8_t) == sizeof(uint8_t)); /* everything breaks otherwise */
     assert(numbits > 0);
 
     val = *pcbitvec;
@@ -198,15 +198,15 @@ char* btob64(const uint8_t* pcbitvec, char* pcout, int numbits)
 ///////////////////////////////////////////////////////////////////////////////
 
 #define NUMTMPLONGS 1000
-char* pltob64(uint32* pl, char* pcout, int numlongs)
+char* pltob64(uint32_t* pl, char* pcout, int numlongs)
 {
     int     i;
-    uint32* plto;
-    uint32           larray[NUMTMPLONGS];
+    uint32_t* plto;
+    uint32_t  larray[NUMTMPLONGS];
 
     assert(numlongs < NUMTMPLONGS);
     /* we use our own ntohl() routines, but we have to do it in-place */
-    memcpy((char*)larray, (char*)pl, numlongs * sizeof(uint32));
+    memcpy((char*)larray, (char*)pl, numlongs * sizeof(uint32_t));
 
     for (i = 0, plto = larray; i < numlongs; i++)
     {
@@ -214,7 +214,7 @@ char* pltob64(uint32* pl, char* pcout, int numlongs)
         ++plto;
     }
 
-    return btob64((uint8_t*)larray, (char*)pcout, numlongs * sizeof(uint32) * 8);
+    return btob64((uint8_t*)larray, (char*)pcout, numlongs * sizeof(uint32_t) * 8);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -261,13 +261,13 @@ bool cNullSignature::IsEqual(const iSignature& rhs) const
     return true;
 }
 
-void cNullSignature::Read(iSerializer* pSerializer, int32 version)
+void cNullSignature::Read(iSerializer* pSerializer, int32_t version)
 {
     if (version > Version())
         ThrowAndAssert(eSerializerVersionMismatch(_T("Null Signature Read")));
 
 #ifdef DEBUG
-    int16 ret;
+    int16_t ret;
     pSerializer->ReadInt16(ret);
     ASSERT(ret == 123);
 #endif
@@ -325,11 +325,11 @@ void cChecksumSignature::Finit()
 TSTRING cChecksumSignature::AsString() const
 {
     TSTRING ret;
-    char*   ps_signature;
-    char    buf[100];
-    uint32  local[2];
-    local[0] = (uint32)(mChecksum >> 32); // note we put the MSB first
-    local[1] = (uint32)(mChecksum);
+    char*     ps_signature;
+    char      buf[100];
+    uint32_t  local[2];
+    local[0] = (uint32_t)(mChecksum >> 32); // note we put the MSB first
+    local[1] = (uint32_t)(mChecksum);
 
     ps_signature = pltob64(local, buf, 2);
     //ps_signature holds base64 representation of mCRC
@@ -347,7 +347,7 @@ TSTRING cChecksumSignature::AsStringHex() const
     ss.setf(ios::hex, ios::basefield);
 
     ASSERT(false);
-    ss << (size_t)(uint32)mChecksum; // TODO:BAM -- this is truncating a 64-bit value to 32 bits!
+    ss << (size_t)(uint32_t)mChecksum; // TODO:BAM -- this is truncating a 64-bit value to 32 bits!
 
     return ss.str();
 }
@@ -357,17 +357,17 @@ bool cChecksumSignature::IsEqual(const iSignature& rhs) const
     return mChecksum == ((cChecksumSignature&)rhs).mChecksum;
 }
 
-void cChecksumSignature::Read(iSerializer* pSerializer, int32 version)
+void cChecksumSignature::Read(iSerializer* pSerializer, int32_t version)
 {
     if (version > Version())
         ThrowAndAssert(eSerializerVersionMismatch(_T("Checksum Signature Read")));
 
-    pSerializer->ReadInt64((int64&)mChecksum);
+    pSerializer->ReadInt64((int64_t&)mChecksum);
 }
 
 void cChecksumSignature::Write(iSerializer* pSerializer) const
 {
-    pSerializer->WriteInt64((int64)mChecksum);
+    pSerializer->WriteInt64((int64_t)mChecksum);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -400,8 +400,8 @@ void cCRC32Signature::Init()
 
 void cCRC32Signature::Update(const uint8_t* const pbData, int cbDataLen)
 {
-    ASSERT(sizeof(uint8_t) == sizeof(uint8));
-    crcUpdate(mCRCInfo, (uint8*)pbData, cbDataLen);
+    ASSERT(sizeof(uint8_t) == sizeof(uint8_t));
+    crcUpdate(mCRCInfo, (uint8_t*)pbData, cbDataLen);
 }
 
 void cCRC32Signature::Finit()
@@ -418,9 +418,9 @@ TSTRING cCRC32Signature::AsString() const
         return AsStringHex();
 
     TSTRING ret;
-    char*   ps_signature;
-    char    buf[100];
-    uint32  local = mCRCInfo.crc;
+    char*     ps_signature;
+    char      buf[100];
+    uint32_t  local = mCRCInfo.crc;
 
     ps_signature = pltob64(&local, buf, 1);
     //ps_signature holds base64 representation of mCRCInfo.crc
@@ -448,17 +448,17 @@ bool cCRC32Signature::IsEqual(const iSignature& rhs) const
         return (mCRCInfo.crc == ((cCRC32Signature&)rhs).mCRCInfo.crc);
 }
 
-void cCRC32Signature::Read(iSerializer* pSerializer, int32 version)
+void cCRC32Signature::Read(iSerializer* pSerializer, int32_t version)
 {
     if (version > Version())
         ThrowAndAssert(eSerializerVersionMismatch(_T("CRC32 Read")));
 
-    pSerializer->ReadInt32((int32&)mCRCInfo.crc);
+    pSerializer->ReadInt32((int32_t&)mCRCInfo.crc);
 }
 
 void cCRC32Signature::Write(iSerializer* pSerializer) const
 {
-    pSerializer->WriteInt32((int32)mCRCInfo.crc);
+    pSerializer->WriteInt32((int32_t)mCRCInfo.crc);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -504,11 +504,11 @@ void cMD5Signature::Init()
 void cMD5Signature::Update(const uint8_t* const pbData, int cbDataLen)
 {
 #ifdef HAVE_COMMONCRYPTO_COMMONDIGEST_H
-    CC_MD5_Update(&mMD5Info, (uint8*)pbData, cbDataLen);
+    CC_MD5_Update(&mMD5Info, (uint8_t*)pbData, cbDataLen);
 #elif HAVE_OPENSSL_MD5_H
-    MD5_Update(&mMD5Info, (uint8*)pbData, cbDataLen);
+    MD5_Update(&mMD5Info, (uint8_t*)pbData, cbDataLen);
 #else
-    MD5Update(&mMD5Info, (uint8*)pbData, cbDataLen);
+    MD5Update(&mMD5Info, (uint8_t*)pbData, cbDataLen);
 #endif
 }
 
@@ -534,7 +534,7 @@ TSTRING cMD5Signature::AsString() const
     TSTRING ret;
     char    buf[24];
 
-    ASSERT(sizeof(uint8) == sizeof(uint8_t)); /* everything breaks otherwise */
+    ASSERT(sizeof(uint8_t) == sizeof(uint8_t)); /* everything breaks otherwise */
     btob64((uint8_t*)md5_digest, buf, SIG_BYTE_SIZE * 8);
     //converting to base64 representation.
 
@@ -550,7 +550,7 @@ TSTRING cMD5Signature::AsStringHex() const
     TCHAR stringBuffer[128];
     TCHAR sigStringOut[129];
     sigStringOut[0] = '\0';
-    uint8* dbuf     = (uint8*)md5_digest;
+    uint8_t* dbuf   = (uint8_t*)md5_digest;
 
     for (int i = 0; i < SIG_BYTE_SIZE; ++i)
     {
@@ -572,7 +572,7 @@ bool cMD5Signature::IsEqual(const iSignature& rhs) const
     }
 }
 
-void cMD5Signature::Read(iSerializer* pSerializer, int32 version)
+void cMD5Signature::Read(iSerializer* pSerializer, int32_t version)
 {
     if (version > Version())
         ThrowAndAssert(eSerializerVersionMismatch(_T("MD5 Read")));
@@ -628,13 +628,13 @@ void cSHASignature::Init()
 
 void cSHASignature::Update(const uint8_t* const pbData, int cbDataLen)
 {
-    ASSERT(sizeof(uint8_t) == sizeof(uint8));
+    ASSERT(sizeof(uint8_t) == sizeof(uint8_t));
 #ifdef HAVE_COMMONCRYPTO_COMMONDIGEST_H
-    CC_SHA1_Update(&mSHAInfo, (uint8*)pbData, cbDataLen);
+    CC_SHA1_Update(&mSHAInfo, (uint8_t*)pbData, cbDataLen);
 #elif HAVE_OPENSSL_SHA_H
-    SHA1_Update(&mSHAInfo, (uint8*)pbData, cbDataLen);
+    SHA1_Update(&mSHAInfo, (uint8_t*)pbData, cbDataLen);
 #else
-    shsUpdate(&mSHAInfo, (uint8*)pbData, cbDataLen);
+    shsUpdate(&mSHAInfo, (uint8_t*)pbData, cbDataLen);
 #endif
 }
 
@@ -661,7 +661,7 @@ TSTRING cSHASignature::AsString(void) const
     char*   ps_signature;
     char    buf[100];
 
-    ps_signature = btob64((uint8*)sha_digest, buf, SIG_UINT32_SIZE * sizeof(uint32) * 8);
+    ps_signature = btob64((uint8_t*)sha_digest, buf, SIG_UINT32_SIZE * sizeof(uint32_t) * 8);
     //converting to base64 representation.
 
     ret.append(ps_signature);
@@ -675,9 +675,9 @@ TSTRING cSHASignature::AsStringHex() const
     TCHAR stringBuffer[128];
     TCHAR sigStringOut[129];
     sigStringOut[0] = '\0';
-    uint8* dbuf     = (uint8*)sha_digest;
+    uint8_t* dbuf   = (uint8_t*)sha_digest;
 
-    for (int i = 0; i < SIG_UINT32_SIZE * (int)sizeof(uint32); ++i)
+    for (int i = 0; i < SIG_UINT32_SIZE * (int)sizeof(uint32_t); ++i)
     {
         snprintf(stringBuffer, 128, _T("%02x"), dbuf[i]);
         strncat(sigStringOut, stringBuffer, 128);
@@ -698,13 +698,13 @@ void cSHASignature::Copy(const iFCOProp* rhs)
 
 ///////////////////////////////////////////////////////////////////////////////
 // Serializer Implementation: Read and Write
-void cSHASignature::Read(iSerializer* pSerializer, int32 version)
+void cSHASignature::Read(iSerializer* pSerializer, int32_t version)
 {
     if (version > Version())
         ThrowAndAssert(eSerializerVersionMismatch(_T("SHA Read")));
 
     for (int i = 0; i < SIG_UINT32_SIZE; ++i)
-        pSerializer->ReadInt32((int32&)sha_digest[i]);
+        pSerializer->ReadInt32((int32_t&)sha_digest[i]);
 }
 
 void cSHASignature::Write(iSerializer* pSerializer) const
@@ -721,7 +721,7 @@ bool cSHASignature::IsEqual(const iSignature& rhs) const
         return true;
     else
     {
-        return (memcmp(sha_digest, ((cSHASignature&)rhs).sha_digest, SIG_UINT32_SIZE * sizeof(uint32)) == 0);
+        return (memcmp(sha_digest, ((cSHASignature&)rhs).sha_digest, SIG_UINT32_SIZE * sizeof(uint32_t)) == 0);
     }
 }
 
@@ -737,7 +737,7 @@ TSTRING cSHASignature::AsString(void) const
     char buf[100];
     buf[99] = 0;
 
-    ps_signature = pltob64((uint32*)mSHAInfo.digest, buf, SIG_UINT32_SIZE);
+    ps_signature = pltob64((uint32_t*)mSHAInfo.digest, buf, SIG_UINT32_SIZE);
     //converting to base64 representation.
 
     ret.append(ps_signature);
@@ -774,13 +774,13 @@ void cSHASignature::Copy(const iFCOProp* rhs)
 
 ///////////////////////////////////////////////////////////////////////////////
 // Serializer Implementation: Read and Write
-void cSHASignature::Read(iSerializer* pSerializer, int32 version)
+void cSHASignature::Read(iSerializer* pSerializer, int32_t version)
 {
     if (version > Version())
         ThrowAndAssert(eSerializerVersionMismatch(_T("SHA Read")));
 
     for (int i = 0; i < SIG_UINT32_SIZE; ++i)
-        pSerializer->ReadInt32((int32&)mSHAInfo.digest[i]);
+        pSerializer->ReadInt32((int32_t&)mSHAInfo.digest[i]);
 }
 
 void cSHASignature::Write(iSerializer* pSerializer) const
@@ -797,7 +797,7 @@ bool cSHASignature::IsEqual(const iSignature& rhs) const
         return true;
     else
     {
-        return (memcmp(mSHAInfo.digest, ((cSHASignature&)rhs).mSHAInfo.digest, SIG_UINT32_SIZE * sizeof(uint32)) == 0);
+        return (memcmp(mSHAInfo.digest, ((cSHASignature&)rhs).mSHAInfo.digest, SIG_UINT32_SIZE * sizeof(uint32_t)) == 0);
     }
 }
 #endif
@@ -824,7 +824,7 @@ void cHAVALSignature::Init()
 
 void cHAVALSignature::Update(const uint8_t* const pbData, int cbDataLen)
 {
-    haval_hash(&mHavalState, (uint8*)pbData, cbDataLen);
+    haval_hash(&mHavalState, (uint8_t*)pbData, cbDataLen);
 }
 
 void cHAVALSignature::Finit()
@@ -877,7 +877,7 @@ void cHAVALSignature::Copy(const iFCOProp* rhs)
 
 ///////////////////////////////////////////////////////////////////////////////
 // Serializer Implementation: Read and Write
-void cHAVALSignature::Read(iSerializer* pSerializer, int32 version)
+void cHAVALSignature::Read(iSerializer* pSerializer, int32_t version)
 {
     if (version > Version())
         ThrowAndAssert(eSerializerVersionMismatch(_T("HAVAL Read")));

--- a/src/fco/signature.h
+++ b/src/fco/signature.h
@@ -198,7 +198,7 @@ public:
     virtual TSTRING AsStringHex() const;
     virtual void    Copy(const iFCOProp* rhs);
 
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 
 protected:
@@ -225,13 +225,13 @@ public:
     virtual TSTRING AsStringHex() const;
     virtual void    Copy(const iFCOProp* rhs);
 
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 
 protected:
     virtual bool IsEqual(const iSignature& rhs) const;
 
-    uint64 mChecksum;
+    uint64_t mChecksum;
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -254,7 +254,7 @@ public:
     virtual TSTRING AsStringHex() const;
     virtual void    Copy(const iFCOProp* rhs);
 
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 
 protected:
@@ -282,7 +282,7 @@ public:
     virtual TSTRING AsStringHex() const;
     virtual void    Copy(const iFCOProp* rhs);
 
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 
 protected:
@@ -294,10 +294,10 @@ protected:
     virtual bool IsEqual(const iSignature& rhs) const;
 #ifdef HAVE_COMMONCRYPTO_COMMONDIGEST_H
     CC_MD5_CTX mMD5Info;
-    uint8      md5_digest[CC_MD5_DIGEST_LENGTH];
+    uint8_t    md5_digest[CC_MD5_DIGEST_LENGTH];
 #else
     MD5_CTX mMD5Info;
-    uint8   md5_digest[MD5_DIGEST_LENGTH];
+    uint8_t md5_digest[MD5_DIGEST_LENGTH];
 #endif
 };
 
@@ -319,7 +319,7 @@ public:
     virtual TSTRING AsStringHex() const;
     virtual void    Copy(const iFCOProp* rhs);
 
-    virtual void Read(iSerializer* pSerializer, int32 version = 0);
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0);
     virtual void Write(iSerializer* pSerializer) const;
 
 protected:
@@ -328,11 +328,11 @@ protected:
 #ifdef HAVE_COMMONCRYPTO_COMMONDIGEST_H
     enum {SIG_UINT32_SIZE = CC_SHA1_DIGEST_LENGTH / 4};
     CC_SHA1_CTX mSHAInfo;
-    uint32      sha_digest[SIG_UINT32_SIZE];
+    uint32_t    sha_digest[SIG_UINT32_SIZE];
 #elif HAVE_OPENSSL_SHA_H
     enum {SIG_UINT32_SIZE = SHA_DIGEST_LENGTH / 4};
-    SHA_CTX mSHAInfo;
-    uint32  sha_digest[SIG_UINT32_SIZE];
+    SHA_CTX     mSHAInfo;
+    uint32_t    sha_digest[SIG_UINT32_SIZE];
 #else
     enum
     {
@@ -361,7 +361,7 @@ public:
     virtual TSTRING AsStringHex() const;
     virtual void    Copy(const iFCOProp* rhs);
 
-    virtual void Read(iSerializer* pSerializer, int32 version = 0);
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0);
     virtual void Write(iSerializer* pSerializer) const;
 
 protected:
@@ -373,7 +373,7 @@ protected:
     virtual bool IsEqual(const iSignature& rhs) const;
 
     haval_state mHavalState;
-    uint8       mSignature[SIG_BYTE_SIZE];
+    uint8_t     mSignature[SIG_BYTE_SIZE];
 };
 
 #endif // __SIGNATURE_H

--- a/src/fs/fsdatasourceiter.h
+++ b/src/fs/fsdatasourceiter.h
@@ -74,7 +74,7 @@ public:
 
     //void TraceContents(int dl = -1) const;
 private:
-    uint64 mDev; // the device number of the last node reached through SeekTo()
+    uint64_t mDev; // the device number of the last node reached through SeekTo()
                  // if this is zero, then it is assumed to be uninitialized
 
     //-------------------------------------------------------------------------

--- a/src/fs/fsobject.cpp
+++ b/src/fs/fsobject.cpp
@@ -107,9 +107,9 @@ void cFSObject::SetName(const cFCOName& name)
 ///////////////////////////////////////////////////////////////////////////////
 // GetCaps
 ///////////////////////////////////////////////////////////////////////////////
-uint32 cFSObject::GetCaps() const
+uint32_t cFSObject::GetCaps() const
 {
-    uint32 cap = mName.GetSize() > 1 ? CAP_CAN_HAVE_PARENT : 0;
+    uint32_t cap = mName.GetSize() > 1 ? CAP_CAN_HAVE_PARENT : 0;
 
     ASSERT(GetFSPropSet().GetValidVector().ContainsItem(cFSPropSet::PROP_FILETYPE));
     if (GetFSPropSet().GetFileType() == cFSPropSet::FT_DIR)
@@ -173,7 +173,7 @@ void cFSObject::AcceptVisitor(iFCOVisitor* pVisitor)
 }
 
 
-void cFSObject::Read(iSerializer* pSerializer, int32 version)
+void cFSObject::Read(iSerializer* pSerializer, int32_t version)
 {
     if (version > Version())
         ThrowAndAssert(eSerializerVersionMismatch(_T("File System Object")));

--- a/src/fs/fsobject.h
+++ b/src/fs/fsobject.h
@@ -67,7 +67,7 @@ public:
 
     virtual const iFCOPropSet* GetPropSet() const;
     virtual iFCOPropSet*       GetPropSet();
-    virtual uint32             GetCaps() const;
+    virtual uint32_t           GetCaps() const;
 
     virtual iFCO* Clone() const;
     virtual void  AcceptVisitor(iFCOVisitor* pVisitor);
@@ -77,7 +77,7 @@ public:
     // returns a reference to the FS property set
 
     // iSerializable interface
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 
     virtual void TraceContents(int dl = -1) const;

--- a/src/fs/fspropdisplayer.cpp
+++ b/src/fs/fspropdisplayer.cpp
@@ -259,7 +259,7 @@ void cFSPropDisplayer::InitForProp(const iFCO* const pFCO, const int propIdx)
     {
     case cFSPropSet::PROP_UID:
     {
-        const int64& i64UID =
+        const int64_t& i64UID =
             static_cast<const cFCOPropInt64*>(pFCO->GetPropSet()->GetPropAt(cFSPropSet::PROP_UID))->GetValue();
 
         // check if prop is in table.  if it is, then don't hit the FS
@@ -278,7 +278,7 @@ void cFSPropDisplayer::InitForProp(const iFCO* const pFCO, const int propIdx)
     break;
     case cFSPropSet::PROP_GID:
     {
-        const int64& i64GID =
+        const int64_t& i64GID =
             static_cast<const cFCOPropInt64*>(pFCO->GetPropSet()->GetPropAt(cFSPropSet::PROP_GID))->GetValue();
 
         // check if prop is in table.  if it is, then don't hit the FS
@@ -341,7 +341,7 @@ TSTRING cFSPropDisplayer::PropAsString(const iFCO* const pFCO, const int propIdx
         case cFSPropSet::PROP_CTIME:
         {
             const cFCOPropInt64* const pTypedProp = static_cast<const cFCOPropInt64*>(pProp);
-            int64                      i64        = pTypedProp->GetValue();
+            int64_t                    i64        = pTypedProp->GetValue();
             cTWLocale::FormatTime(i64, strProp);
         }
         break;
@@ -360,7 +360,8 @@ TSTRING cFSPropDisplayer::PropAsString(const iFCO* const pFCO, const int propIdx
             if (GetUsername(pTypedProp->GetValue(), strProp))
             {
                 TSTRINGSTREAM ostr;
-                ostr << strProp << _T(" (") << (int32)pTypedProp->GetValue() << _T(")");
+                //TODO: can we get rid of this cast now?
+                ostr << strProp << _T(" (") << (int32_t)pTypedProp->GetValue() << _T(")");
                 strProp = ostr.str();
             }
             else
@@ -374,7 +375,8 @@ TSTRING cFSPropDisplayer::PropAsString(const iFCO* const pFCO, const int propIdx
             if (GetGroupname(pTypedProp->GetValue(), strProp))
             {
                 TSTRINGSTREAM ostr;
-                ostr << strProp << _T(" (") << (int32)pTypedProp->GetValue() << _T(")");
+                //TODO: can we get rid of this cast now?
+                ostr << strProp << _T(" (") << (int32_t)pTypedProp->GetValue() << _T(")");
                 strProp = ostr.str();
             }
             else
@@ -422,21 +424,21 @@ void cFSPropDisplayer::Write(iSerializer* pSerializer) const
     }
 }
 
-void cFSPropDisplayer::Read(iSerializer* pSerializer, int32 version)
+void cFSPropDisplayer::Read(iSerializer* pSerializer, int32_t version)
 {
     if (version > Version())
         ThrowAndAssert(eSerializerVersionMismatch(_T("Property Displayer Read")));
 
     mpvPropsWeDisplay.Read(pSerializer);
 
-    int32 iDummy;
+    int32_t iDummy;
     pSerializer->ReadInt32(iDummy);
     mbLazy = iDummy == 0 ? false : true;
 
     //  stuff
     {
-        int32   nValues;
-        int64   key;
+        int32_t nValues;
+        int64_t key;
         TSTRING val;
         int     i;
 
@@ -465,7 +467,7 @@ void cFSPropDisplayer::Read(iSerializer* pSerializer, int32 version)
 // Lookup functions
 //////////////////////////////////////////////
 
-bool cFSPropDisplayer::GetUsername(const int64& i64uid, TSTRING& tstrUsername) const
+bool cFSPropDisplayer::GetUsername(const int64_t& i64uid, TSTRING& tstrUsername) const
 {
     bool fFound = false;
 
@@ -480,7 +482,7 @@ bool cFSPropDisplayer::GetUsername(const int64& i64uid, TSTRING& tstrUsername) c
     return (fFound && !tstrUsername.empty());
 }
 
-bool cFSPropDisplayer::GetGroupname(const int64& i64gid, TSTRING& tstrGroupname) const
+bool cFSPropDisplayer::GetGroupname(const int64_t& i64gid, TSTRING& tstrGroupname) const
 {
     bool fFound = false;
 
@@ -499,14 +501,14 @@ bool cFSPropDisplayer::GetGroupname(const int64& i64gid, TSTRING& tstrGroupname)
 // Addition functions
 //////////////////////////////////////////////
 
-bool cFSPropDisplayer::AddUsernameMapping(const int64& i64uid, const TSTRING& tstrUsername)
+bool cFSPropDisplayer::AddUsernameMapping(const int64_t& i64uid, const TSTRING& tstrUsername)
 {
     std::pair<INT64_TO_STRING_MAP::iterator, bool> ret =
         uidToUsername.insert(INT64_TO_STRING_MAP::value_type(i64uid, tstrUsername));
     return (ret.second = false); // returns true if key didn't exist before
 }
 
-bool cFSPropDisplayer::AddGroupnameMapping(const int64& i64gid, const TSTRING& tstrGroupname)
+bool cFSPropDisplayer::AddGroupnameMapping(const int64_t& i64gid, const TSTRING& tstrGroupname)
 {
     std::pair<INT64_TO_STRING_MAP::iterator, bool> ret =
         gidToGroupname.insert(INT64_TO_STRING_MAP::value_type(i64gid, tstrGroupname));

--- a/src/fs/fspropdisplayer.h
+++ b/src/fs/fspropdisplayer.h
@@ -128,10 +128,10 @@ private:
 
     typedef std::map<int64_t, TSTRING> INT64_TO_STRING_MAP;
 
-    bool GetUsername(  const int64_t& i64uid, TSTRING& tstrUsername) const;
-    bool GetGroupname( const int64_t& i64uid, TSTRING& tstrGroupname) const;
-    bool AddUsernameMapping(  const int64_t& i64ID, const TSTRING& tstrUsername);
-    bool AddGroupnameMapping( const int64_t& i64ID, const TSTRING& tstrGroupname);
+    bool GetUsername(const int64_t& i64uid, TSTRING& tstrUsername) const;
+    bool GetGroupname(const int64_t& i64uid, TSTRING& tstrGroupname) const;
+    bool AddUsernameMapping(const int64_t& i64ID, const TSTRING& tstrUsername);
+    bool AddGroupnameMapping(const int64_t& i64ID, const TSTRING& tstrGroupname);
 
     // storage for conversion stuff
     INT64_TO_STRING_MAP uidToUsername;

--- a/src/fs/fspropdisplayer.h
+++ b/src/fs/fspropdisplayer.h
@@ -112,7 +112,7 @@ public:
     virtual void     InitForFCO(const iFCO* const ifco);
     virtual void     SetLazy(const bool bLazy = true);
     virtual bool     GetLazy() const;
-    virtual void     Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void     Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void     Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 
     bool operator==(const cFSPropDisplayer& rhs) const; // for testing
@@ -126,12 +126,12 @@ private:
                                       // can do a PropAsString that's different from iFCOProp::AsString()
     bool mbLazy;
 
-    typedef std::map<int64, TSTRING> INT64_TO_STRING_MAP;
+    typedef std::map<int64_t, TSTRING> INT64_TO_STRING_MAP;
 
-    bool GetUsername(const int64& i64uid, TSTRING& tstrUsername) const;
-    bool GetGroupname(const int64& i64uid, TSTRING& tstrGroupname) const;
-    bool AddUsernameMapping(const int64& i64ID, const TSTRING& tstrUsername);
-    bool AddGroupnameMapping(const int64& i64ID, const TSTRING& tstrGroupname);
+    bool GetUsername(  const int64_t& i64uid, TSTRING& tstrUsername) const;
+    bool GetGroupname( const int64_t& i64uid, TSTRING& tstrGroupname) const;
+    bool AddUsernameMapping(  const int64_t& i64ID, const TSTRING& tstrUsername);
+    bool AddGroupnameMapping( const int64_t& i64ID, const TSTRING& tstrGroupname);
 
     // storage for conversion stuff
     INT64_TO_STRING_MAP uidToUsername;

--- a/src/fs/fspropset.cpp
+++ b/src/fs/fspropset.cpp
@@ -61,7 +61,7 @@ TSTRING cFCOPropFileType::AsString() const
                               fs::STR_FT_PORT,
                               fs::STR_FT_NAMED};
 
-    int32 fileType = GetValue();
+    int32_t fileType = GetValue();
     if ((fileType > cFSPropSet::FT_INVALID) && (fileType < cFSPropSet::FT_NUMITEMS))
         return TSS_GetString(cFS, fileTypes[fileType]);
     else
@@ -358,7 +358,7 @@ iFCOProp* cFSPropSet::GetPropAt(int index)
     return NULL;
 }
 
-void cFSPropSet::Read(iSerializer* pSerializer, int32 version)
+void cFSPropSet::Read(iSerializer* pSerializer, int32_t version)
 {
     if (version > Version())
         ThrowAndAssert(eSerializerVersionMismatch(_T("FS Property Set Read")));

--- a/src/fs/fspropset.h
+++ b/src/fs/fspropset.h
@@ -55,7 +55,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 // cFCOPropFileType -- a property that represents a file type. Is is really just
-//      an int32 that overrides the AsString() method to display the file type
+//      an int32_t that overrides the AsString() method to display the file type
 ///////////////////////////////////////////////////////////////////////////////
 class cFCOPropFileType : public cFCOPropInt32
 {
@@ -166,7 +166,7 @@ public:
     //PROPERTY_OBJ(cUnixACL,        ACL,            PROP_ACL)  // will eventually be implememented
 
     // iSerializable interface
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 
     // debugging method

--- a/src/tripwire/generatedb.cpp
+++ b/src/tripwire/generatedb.cpp
@@ -119,7 +119,7 @@ static void util_ProcessDir(
 // Execute
 ///////////////////////////////////////////////////////////////////////////////
 void cGenerateDb::Execute(
-    const cFCOSpecList& specList, cHierDatabase& db, iFCOPropDisplayer* pPD, cErrorBucket* pBucket, uint32 flags)
+    const cFCOSpecList& specList, cHierDatabase& db, iFCOPropDisplayer* pPD, cErrorBucket* pBucket, uint32_t flags)
 {
     // TODO -- assert the db is empty or clear it out myself!
 

--- a/src/tripwire/generatedb.h
+++ b/src/tripwire/generatedb.h
@@ -53,7 +53,7 @@ public:
                         cHierDatabase&      db,
                         iFCOPropDisplayer*  pPD,
                         cErrorBucket*       pBucket,
-                        uint32              flags = 0);
+                        uint32_t            flags = 0);
     // generates a tripwire database; this asserts that the database is open
 
     enum Flags

--- a/src/tripwire/integritycheck.cpp
+++ b/src/tripwire/integritycheck.cpp
@@ -271,7 +271,7 @@ void cIntegrityCheck::CompareFCOs(iFCO* pOldFCO, iFCO* pNewFCO)
     // construct the compare object and actually do the compare
     //
     cFCOCompare compareObj(propsToCheck);
-    uint32      result = compareObj.Compare(pOldFCO, pNewFCO);
+    uint32_t    result = compareObj.Compare(pOldFCO, pNewFCO);
 
     if ((result & cFCOCompare::PROPS_UNEQUAL) || (result & cFCOCompare::PROPS_NOT_ALL_VALID))
     {
@@ -451,7 +451,7 @@ cIntegrityCheck::~cIntegrityCheck()
 ///////////////////////////////////////////////////////////////////////////////
 // Execute
 ///////////////////////////////////////////////////////////////////////////////
-void cIntegrityCheck::Execute(uint32 flags)
+void cIntegrityCheck::Execute(uint32_t flags)
 {
     mFlags = flags;
     // create the data source iterator
@@ -557,7 +557,7 @@ void cIntegrityCheck::Execute(uint32 flags)
 ///////////////////////////////////////////////////////////////////////////////
 // ExecuteOnObjectList
 ///////////////////////////////////////////////////////////////////////////////
-void cIntegrityCheck::ExecuteOnObjectList(const std::list<cFCOName>& fcoNames, uint32 flags)
+void cIntegrityCheck::ExecuteOnObjectList(const std::list<cFCOName>& fcoNames, uint32_t flags)
 {
     iFCONameTranslator* pTrans = iTWFactory::GetInstance()->GetNameTranslator();
     //

--- a/src/tripwire/integritycheck.h
+++ b/src/tripwire/integritycheck.h
@@ -87,10 +87,10 @@ public:
 
     ~cIntegrityCheck();
 
-    void Execute(uint32 flags = 0);
+    void Execute(uint32_t flags = 0);
     // flags should be 0, or some combination of the below enumeration
     // TODO -- specify what kinds of exception can come up from here....
-    void ExecuteOnObjectList(const std::list<cFCOName>& fcoNames, uint32 flags = 0);
+    void ExecuteOnObjectList(const std::list<cFCOName>& fcoNames, uint32_t flags = 0);
     // executes an integrity check on the objects named in the list. The specList passed in
     // as the first parameter to the ctor is interprited as the db's spec list.
     int ObjectsScanned()
@@ -133,7 +133,7 @@ private:
     iFCOSpec*            mpCurSpec;        // the spec we are currently operating on
     cFCOReportSpecIter   mReportIter;      // the current iterator into the report
     cFCOPropVector       mLooseDirProps;   // properties that should be ignored in loose directories
-    uint32               mFlags;           // flags passed in to execute()
+    uint32_t             mFlags;           // flags passed in to execute()
     int                  mnObjectsScanned; // number of objects scanned in system ( scanning includes
                                            // discovering that an FCO does not exist )
 

--- a/src/tripwire/mailmessage.cpp
+++ b/src/tripwire/mailmessage.cpp
@@ -242,7 +242,7 @@ bool cMailMessageUtil::ReadDate(TSTRING& strDateBuf)
 
 #else
 
-    int64 now  = cSystemInfo::GetExeStartTime();
+    int64_t now  = cSystemInfo::GetExeStartTime();
     strDateBuf = cTimeUtil::GetRFC822Date(cTimeUtil::TimeToDateGMT(now));
     fGotDate   = true;
 
@@ -591,7 +591,7 @@ cMailMessageUtil::ConvertBase64(
 std::string 
 cMailMessageUtil::ToBase64( const uint8_t* p, size_t size )
 {
-    ASSERT( sizeof( uint8 ) == sizeof( uint8_t ) ); // everything breaks otherwise
+    ASSERT( sizeof( uint8_t ) == sizeof( uint8_t ) ); // everything breaks otherwise
     std::string s;    
 
     const int MAX_WORKING_BYTES = 3;

--- a/src/tripwire/policyupdate.cpp
+++ b/src/tripwire/policyupdate.cpp
@@ -142,7 +142,7 @@ cPolicyUpdate::cPolicyUpdate(cGenre::Genre       genreNum,
 ///////////////////////////////////////////////////////////////////////////////
 // Execute
 ///////////////////////////////////////////////////////////////////////////////
-bool cPolicyUpdate::Execute(uint32 flags) // throw (eError)
+bool cPolicyUpdate::Execute(uint32_t flags) // throw (eError)
 {
     // here is my current idea for the algorithm: first, do an integrity check with the new policy on the database and
     // a special flag passed to Execute() to modify what properties are checked. Then, take the resulting
@@ -166,7 +166,7 @@ bool cPolicyUpdate::Execute(uint32 flags) // throw (eError)
     //
     // set up flags for the property calculator and iterators
     //
-    uint32 icFlags = cIntegrityCheck::FLAG_COMPARE_VALID_PROPS_ONLY | cIntegrityCheck::FLAG_INVALIDATE_EXTRA_DB_PROPS |
+    uint32_t icFlags = cIntegrityCheck::FLAG_COMPARE_VALID_PROPS_ONLY | cIntegrityCheck::FLAG_INVALIDATE_EXTRA_DB_PROPS |
                      cIntegrityCheck::FLAG_SET_NEW_PROPS;
 
     if (flags & FLAG_ERASE_FOOTPRINTS_PU)
@@ -279,7 +279,7 @@ bool cPolicyUpdate::Execute(uint32 flags) // throw (eError)
     //
     cUpdateDb update(mDb, report, mpBucket);
 
-    uint32 updateDBFlags = cUpdateDb::FLAG_REPLACE_PROPS;
+    uint32_t updateDBFlags = cUpdateDb::FLAG_REPLACE_PROPS;
     if (flags & FLAG_ERASE_FOOTPRINTS_PU)
     {
         updateDBFlags |= cUpdateDb::FLAG_ERASE_FOOTPRINTS_UD;

--- a/src/tripwire/policyupdate.h
+++ b/src/tripwire/policyupdate.h
@@ -65,7 +65,7 @@ public:
                   cHierDatabase&      db,
                   cErrorBucket*       pBucket);
 
-    bool Execute(uint32 flags = 0); // throw (eError)
+    bool Execute(uint32_t flags = 0); // throw (eError)
         // if false is returned, then there was at least one conflict that came up during the policy
         // update, and if tripwire was run in secure mode then the policy update should fail.
 

--- a/src/tripwire/smtpmailmessage.cpp
+++ b/src/tripwire/smtpmailmessage.cpp
@@ -211,7 +211,7 @@ bool cSMTPMailMessage::OpenConnection()
     memset(&sockAddrIn, 0, sizeof(sockaddr));
     sockAddrIn.sin_family = AF_INET;
     sockAddrIn.sin_port = mPfnHtons(mPortNumber);
-    uint32 iServerAddress = GetServerAddress();
+    uint32_t iServerAddress = GetServerAddress();
 
     sockAddrIn.sin_addr.s_addr = iServerAddress;
 

--- a/src/tripwire/tripwiremain.cpp
+++ b/src/tripwire/tripwiremain.cpp
@@ -68,7 +68,7 @@ static TSTRING util_GetWholeCmdLine(int argc, const TCHAR* argv[]);
 #if defined(HAVE_MALLOC_H)
 #include <malloc.h>
 #endif
-static int32    gCurAlloc=0, 
+static int32_t  gCurAlloc=0,
                 gMaxAlloc=0;
 void* operator new(size_t size)
 {

--- a/src/tripwire/twcmdline.cpp
+++ b/src/tripwire/twcmdline.cpp
@@ -759,7 +759,7 @@ int cTWModeDbInit::Execute(cErrorQueue* pQueue)
 
         iUserNotify::GetInstance()->Notify(1, TSS_GetString(cTripwire, tripwire::STR_GENERATING_DB).c_str());
 
-        uint32 gdbFlags = 0;
+        uint32_t gdbFlags = 0;
         gdbFlags |= (mpData->mbResetAccessTime ? cGenerateDb::FLAG_ERASE_FOOTPRINTS_GD : 0);
         gdbFlags |= (mpData->mbDirectIO ? cGenerateDb::FLAG_DIRECT_IO : 0);
 
@@ -1255,7 +1255,7 @@ int cTWModeIC::Execute(cErrorQueue* pQueue)
                     //If any sort of exception escapes the IC, make sure it goes in the report.
                     try
                     {
-                        uint32 icFlags = 0;
+                        uint32_t icFlags = 0;
                         icFlags |= (mpData->mfLooseDirs ? cIntegrityCheck::FLAG_LOOSE_DIR : 0);
                         icFlags |= (mpData->mbResetAccessTime ? cIntegrityCheck::FLAG_ERASE_FOOTPRINTS_IC : 0);
                         icFlags |= (mpData->mbDirectIO ? cIntegrityCheck::FLAG_DIRECT_IO : 0);
@@ -1408,7 +1408,7 @@ int cTWModeIC::Execute(cErrorQueue* pQueue)
                     //If any sort of exception escapes the IC, make sure it goes in the report.
                     try
                     {
-                        uint32 icFlags = 0;
+                        uint32_t icFlags = 0;
                         icFlags |= (mpData->mfLooseDirs ? cIntegrityCheck::FLAG_LOOSE_DIR : 0);
                         icFlags |= (mpData->mbResetAccessTime ? cIntegrityCheck::FLAG_ERASE_FOOTPRINTS_IC : 0);
                         icFlags |= (mpData->mbDirectIO ? cIntegrityCheck::FLAG_DIRECT_IO : 0);
@@ -1886,7 +1886,7 @@ int cTWModeDbUpdate::Execute(cErrorQueue* pQueue)
             //
             // actually do the integrity check...
             //
-            uint32 udFlags = 0;
+            uint32_t udFlags = 0;
             udFlags |= (mpData->mbResetAccessTime ? cUpdateDb::FLAG_ERASE_FOOTPRINTS_UD : 0);
 
             cUpdateDb update(dbIter.GetDb(), *mpData->mpReport, pQueue);
@@ -2213,7 +2213,7 @@ int cTWModePolUpdate::Execute(cErrorQueue* pQueue)
                 //
                 cPolicyUpdate pu(
                     genreIter->GetGenre(), dbIter.GetSpecList(), genreIter->GetSpecList(), dbIter.GetDb(), pQueue);
-                uint32 puFlags = 0;
+                uint32_t puFlags = 0;
                 puFlags |= mpData->mbSecureMode ? cPolicyUpdate::FLAG_SECURE_MODE : 0;
                 puFlags |= (mpData->mbResetAccessTime ? cPolicyUpdate::FLAG_ERASE_FOOTPRINTS_PU : 0);
                 puFlags |= (mpData->mbDirectIO ? cPolicyUpdate::FLAG_DIRECT_IO : 0);
@@ -2245,7 +2245,7 @@ int cTWModePolUpdate::Execute(cErrorQueue* pQueue)
                 // generate the database...
                 // TODO -- turn pQueue into an error bucket
 
-                uint32 gdbFlags = 0;
+                uint32_t gdbFlags = 0;
                 gdbFlags |= (mpData->mbResetAccessTime ? cGenerateDb::FLAG_ERASE_FOOTPRINTS_GD : 0);
                 gdbFlags |= (mpData->mbDirectIO ? cGenerateDb::FLAG_DIRECT_IO : 0);
 

--- a/src/tripwire/updatedb.cpp
+++ b/src/tripwire/updatedb.cpp
@@ -60,7 +60,7 @@ cUpdateDb::cUpdateDb(cHierDatabase& db, cFCOReport& report, cErrorBucket* pBucke
 ///////////////////////////////////////////////////////////////////////////////
 // Execute
 ///////////////////////////////////////////////////////////////////////////////
-bool cUpdateDb::Execute(uint32 flags)
+bool cUpdateDb::Execute(uint32_t flags)
 {
     cDebug d("cUpdateDb::Execute");
     bool   bResult = true;

--- a/src/tripwire/updatedb.h
+++ b/src/tripwire/updatedb.h
@@ -56,7 +56,7 @@ class cUpdateDb
 public:
     cUpdateDb(cHierDatabase& db, cFCOReport& report, cErrorBucket* pBucket);
 
-    bool Execute(uint32 flags = 0);
+    bool Execute(uint32_t flags = 0);
     // returns false if there were any conflicts in updating
     // the database
     // TODO -- what kind of exceptions can come up from here?

--- a/src/tw/dbdatasource.cpp
+++ b/src/tw/dbdatasource.cpp
@@ -143,8 +143,8 @@ iFCO* cDbDataSourceIter::CreateFCO() //throw (eError)
     try
     {
         ASSERT(mDbIter.HasData());
-        int32 length;
-        int8* pData = mDbIter.GetData(length);
+        int32_t length;
+        int8_t* pData = mDbIter.GetData(length);
         //
         // associate a serializer with this memory and read in the property set...
         //

--- a/src/tw/dbdatasource.h
+++ b/src/tw/dbdatasource.h
@@ -132,7 +132,7 @@ private:
 
     cHierDatabase::iterator     mDbIter;
     iSerRefCountObj::CreateFunc mFCOCreateFunc; // points to the function that creates the fcos we return
-    uint32                      mFlags;         // flags used for iteration
+    uint32_t                    mFlags;         // flags used for iteration
     cErrorBucket*               mpErrorBucket;
 };
 

--- a/src/tw/fcodatabasefile.cpp
+++ b/src/tw/fcodatabasefile.cpp
@@ -81,7 +81,7 @@ cFCODatabaseFile::~cFCODatabaseFile()
 ///////////////////////////////////////////////////////////////////////////////
 // Read
 ///////////////////////////////////////////////////////////////////////////////
-void cFCODatabaseFile::Read(iSerializer* pSerializer, int32 version)
+void cFCODatabaseFile::Read(iSerializer* pSerializer, int32_t version)
 {
     if (version > Version())
         ThrowAndAssert(eSerializerVersionMismatch(_T("Database Read")));
@@ -91,13 +91,13 @@ void cFCODatabaseFile::Read(iSerializer* pSerializer, int32 version)
     //
     pSerializer->ReadObject(&mHeader);
 
-    int32 numGenre;
+    int32_t numGenre;
     pSerializer->ReadInt32(numGenre);
     for (int i = 0; i < numGenre; i++)
     {
         // read the genre number and throw if it is incorrect
         //
-        int32 iGenre;
+        int32_t iGenre;
         pSerializer->ReadInt32(iGenre);
         cGenre::Genre genre = (cGenre::Genre)iGenre;
 
@@ -121,7 +121,7 @@ void cFCODatabaseFile::Read(iSerializer* pSerializer, int32 version)
         //
         // get the database data
         //
-        int32 fileSize;
+        int32_t fileSize;
         pSerializer->ReadInt32(fileSize);
         //
         // write the hier database into a temp file...
@@ -170,7 +170,7 @@ void cFCODatabaseFile::Write(iSerializer* pSerializer) const //throw( eFCODbFile
         if (pDbArch->Length() > TSS_INT32_MAX)
             throw eFCODbFileTooBig();
 
-        pSerializer->WriteInt32(static_cast<int32>(pDbArch->Length()));
+        pSerializer->WriteInt32(static_cast<int32_t>(pDbArch->Length()));
         cSerializerUtil::Copy(pSerializer, pDbArch, pDbArch->Length());
     }
 }

--- a/src/tw/fcodatabasefile.h
+++ b/src/tw/fcodatabasefile.h
@@ -100,7 +100,7 @@ public:
     ///////////////////////////////
     // serialization interface
     ///////////////////////////////
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 
 

--- a/src/tw/fcodatabaseutil.cpp
+++ b/src/tw/fcodatabaseutil.cpp
@@ -58,8 +58,8 @@ void cFCODatabaseUtil::CalculateHeader(cFCODbHeader&  dbHeader,
                                        const TSTRING& configFilename,
                                        const TSTRING& dbFilename,
                                        const TSTRING& commandLineParams,
-                                       int64          createTime,
-                                       int64          lastDBUpdateTime)
+                                       int64_t        createTime,
+                                       int64_t        lastDBUpdateTime)
 {
     cDebug d("cFCODatabaseUtil::CalculateHeaderInfo");
 

--- a/src/tw/fcodatabaseutil.h
+++ b/src/tw/fcodatabaseutil.h
@@ -59,8 +59,8 @@ public:
                                 const TSTRING& configFilename,
                                 const TSTRING& dbFilename,
                                 const TSTRING& commandLineParams,
-                                int64          createTime,
-                                int64          lastDBUpdateTime);
+                                int64_t        createTime,
+                                int64_t        lastDBUpdateTime);
     //Calculates and gathers header data, stores results in header.
 private:
 };

--- a/src/tw/fcoreport.cpp
+++ b/src/tw/fcoreport.cpp
@@ -85,7 +85,7 @@ public:
         cFCOSetWS              mRemoved;
         std::list<cChangeNode> mChanged;
         cErrorQueue            mErrorQueue;
-        int32                  mnObjectsScanned;
+        int32_t               mnObjectsScanned;
 
         cNode();
         cNode(const cNode& rhs);
@@ -753,7 +753,7 @@ void cFCOReport::AddChangedFCO(const cFCOReportSpecIter& iter,
 ///////////////////////////////////////////////////////////////////////////////
 // iSerializable interface
 ///////////////////////////////////////////////////////////////////////////////
-void cFCOReport::Read(iSerializer* pSerializer, int32 version)
+void cFCOReport::Read(iSerializer* pSerializer, int32_t version)
 {
     if (version > Version())
         ThrowAndAssert(eSerializerVersionMismatch(_T("Report Read")));
@@ -764,14 +764,14 @@ void cFCOReport::Read(iSerializer* pSerializer, int32 version)
     pSerializer->ReadObject(&mpData->mErrorQueue);
 
     // read in the genres
-    int32 genreIter, genreCount;
-    int32 specIter, specCount;
+    int32_t genreIter, genreCount;
+    int32_t specIter, specCount;
 
     pSerializer->ReadInt32(genreCount);
     for (genreIter = 0; genreIter < genreCount; genreIter++)
     {
         cFCOReport_i::cGenreNode newGenre;
-        int32                    genre;
+        int32_t                  genre;
 
         // TODO:BAM -- this used to be int16, so take care of backwards compatability
         pSerializer->ReadInt32(genre);
@@ -791,12 +791,12 @@ void cFCOReport::Read(iSerializer* pSerializer, int32 version)
             pSerializer->ReadObject(&node.mErrorQueue);
             pSerializer->ReadObject(&node.mAdded);
             pSerializer->ReadObject(&node.mRemoved);
-            pSerializer->ReadInt32(node.mnObjectsScanned);
+            pSerializer->ReadInt32((int32_t&)node.mnObjectsScanned);
 
             node.mAdded.SetSpec(node.mpSpec);
             node.mRemoved.SetSpec(node.mpSpec);
 
-            int32 changeSize;
+            int32_t changeSize;
             pSerializer->ReadInt32(changeSize);
             for (int j = 0; j < changeSize; j++)
             {

--- a/src/tw/fcoreport.h
+++ b/src/tw/fcoreport.h
@@ -128,7 +128,7 @@ public:
     void TraceContents(int dl = -1) const;
 
     // iSerializable interface
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 
     static const cFileHeaderID& GetFileHeaderID();

--- a/src/tw/fcoreportutil.cpp
+++ b/src/tw/fcoreportutil.cpp
@@ -63,8 +63,8 @@ void cFCOReportUtil::CalculateHeaderInfo(cFCOReportHeader& reportHeader,
                                          const TSTRING&    configFilename,
                                          const TSTRING&    dbFilename,
                                          const TSTRING&    commandLineParams,
-                                         int64             createTime,
-                                         int64             lastDBUpdateTime)
+                                         int64_t           createTime,
+                                         int64_t           lastDBUpdateTime)
 {
     reportHeader.SetPolicyFilename(policyFilename);
     reportHeader.SetConfigFilename(configFilename);

--- a/src/tw/fcoreportutil.h
+++ b/src/tw/fcoreportutil.h
@@ -58,8 +58,8 @@ public:
                                     const TSTRING&    configFilename,
                                     const TSTRING&    dbFilename,
                                     const TSTRING&    commandLineParams,
-                                    int64             createTime,
-                                    int64             lastDBUpdateTime);
+                                    int64_t           createTime,
+                                    int64_t           lastDBUpdateTime);
 
     static void FinalizeReport(cFCOReport& rr);
     // call this when you're done adding to the report.

--- a/src/tw/filemanipulator.cpp
+++ b/src/tw/filemanipulator.cpp
@@ -115,7 +115,7 @@ const cFileHeaderID* cFileManipulator::GetHeaderID()
     return &mFileHeader.GetID();
 }
 
-uint32 cFileManipulator::GetFileVersion()
+uint32_t cFileManipulator::GetFileVersion()
 {
     ASSERT(mbInit);
     if (!mbInit)

--- a/src/tw/filemanipulator.h
+++ b/src/tw/filemanipulator.h
@@ -100,7 +100,7 @@ public:
     // information for this file
     TSTRING               GetFileName() const;
     const cFileHeaderID*  GetHeaderID();    // returns NULL if error code is non-zero
-    uint32                GetFileVersion(); // throws eFileManipulator if error code is non-zero
+    uint32_t              GetFileVersion(); // throws eFileManipulator if error code is non-zero
     cFileHeader::Encoding GetEncoding();    // throws eFileManipulator if error code is non-zero
 
     // things you can do to this file

--- a/src/tw/headerinfo.cpp
+++ b/src/tw/headerinfo.cpp
@@ -76,7 +76,7 @@ void cHeaderInfo::Clear()
 }
 
 
-void cHeaderInfo::Read(iSerializer* pSerializer, int32 version) // throw (eSerializer, eArchive)
+void cHeaderInfo::Read(iSerializer* pSerializer, int32_t version) // throw (eSerializer, eArchive)
 {
     if (version > Version())
         ThrowAndAssert(eSerializerVersionMismatch(_T("cHeaderInfo Read")));
@@ -138,7 +138,7 @@ void cGenreHeaderInfo::Clear()
     i32_ObjectsScanned = 0;
 }
 
-void cGenreHeaderInfo::Read(iSerializer* pSerializer, int32 version) // throw (eSerializer, eArchive)
+void cGenreHeaderInfo::Read(iSerializer* pSerializer, int32_t version) // throw (eSerializer, eArchive)
 {
     if (version > Version())
         ThrowAndAssert(eSerializerVersionMismatch(_T("cHeaderInfo Read")));
@@ -146,7 +146,7 @@ void cGenreHeaderInfo::Read(iSerializer* pSerializer, int32 version) // throw (e
     // read the prop displayer
     ASSERT(mpPropDisplayer == 0);
 
-    int32 fMakePD;
+    int32_t fMakePD;
     pSerializer->ReadInt32(fMakePD);
 
     if (fMakePD == 1)

--- a/src/tw/headerinfo.h
+++ b/src/tw/headerinfo.h
@@ -121,7 +121,7 @@ public:
     const iFCOPropDisplayer* GetPropDisplayer() const;
 
     void                     SetObjectsScanned(int32_t);
-    int32_t                 GetObjectsScanned() const;
+    int32_t                  GetObjectsScanned() const;
 
     // iSerializable interface
     virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
@@ -130,7 +130,7 @@ private:
     cGenreHeaderInfo& operator=(cGenreHeaderInfo&);
 
     iFCOPropDisplayer* mpPropDisplayer;
-    int32_t           i32_ObjectsScanned;
+    int32_t            i32_ObjectsScanned;
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/tw/headerinfo.h
+++ b/src/tw/headerinfo.h
@@ -67,8 +67,8 @@ public:
     const TSTRING& GetIPAddress() const;
     const TSTRING& GetCreator() const;
     const TSTRING& GetHostID() const;
-    int64          GetCreationTime() const;
-    int64          GetLastDBUpdateTime() const;
+    int64_t        GetCreationTime() const;
+    int64_t        GetLastDBUpdateTime() const;
     //Set:
     void SetPolicyFilename(const TSTRING&);
     void SetConfigFilename(const TSTRING&);
@@ -78,27 +78,27 @@ public:
     void SetIPAddress(const TSTRING&);
     void SetCreator(const TSTRING&);
     void SetHostID(const TSTRING&);
-    void SetCreationTime(int64);
-    void SetLastDBUpdateTime(int64);
+    void SetCreationTime(int64_t);
+    void SetLastDBUpdateTime(int64_t);
 
     // iSerializable interface
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 
 private:
     cHeaderInfo& operator=(cHeaderInfo&);
 
     //Header Data:
-    TSTRING       tstr_PolicyFilename;
-    TSTRING       tstr_ConfigFilename;
-    TSTRING       tstr_DBFilename;
-    TSTRING       tstr_SystemName;
-    TSTRING       tstr_CommandLineParams;
-    TSTRING       tstr_IPAddress;
-    TSTRING       tstr_CreatedBy;
-    TSTRING       tstr_HostID;
-    int64         i64_CreationTime;
-    mutable int64 i64_LastDBUpdateTime;
+    TSTRING         tstr_PolicyFilename;
+    TSTRING         tstr_ConfigFilename;
+    TSTRING         tstr_DBFilename;
+    TSTRING         tstr_SystemName;
+    TSTRING         tstr_CommandLineParams;
+    TSTRING         tstr_IPAddress;
+    TSTRING         tstr_CreatedBy;
+    TSTRING         tstr_HostID;
+    int64_t         i64_CreationTime;
+    mutable int64_t i64_LastDBUpdateTime;
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -120,17 +120,17 @@ public:
     iFCOPropDisplayer*       GetPropDisplayer();
     const iFCOPropDisplayer* GetPropDisplayer() const;
 
-    void  SetObjectsScanned(int32);
-    int32 GetObjectsScanned() const;
+    void                     SetObjectsScanned(int32_t);
+    int32_t                 GetObjectsScanned() const;
 
     // iSerializable interface
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 private:
     cGenreHeaderInfo& operator=(cGenreHeaderInfo&);
 
     iFCOPropDisplayer* mpPropDisplayer;
-    int32              i32_ObjectsScanned;
+    int32_t           i32_ObjectsScanned;
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -226,11 +226,11 @@ inline const TSTRING& cHeaderInfo::GetHostID() const
 {
     return tstr_HostID;
 };
-inline int64 cHeaderInfo::GetCreationTime() const
+inline int64_t cHeaderInfo::GetCreationTime() const
 {
     return i64_CreationTime;
 };
-inline int64 cHeaderInfo::GetLastDBUpdateTime() const
+inline int64_t cHeaderInfo::GetLastDBUpdateTime() const
 {
     return i64_LastDBUpdateTime;
 };
@@ -267,11 +267,11 @@ inline void cHeaderInfo::SetIPAddress(const TSTRING& tstr)
 {
     tstr_IPAddress = tstr;
 };
-inline void cHeaderInfo::SetCreationTime(int64 i)
+inline void cHeaderInfo::SetCreationTime(int64_t i)
 {
     i64_CreationTime = i;
 };
-inline void cHeaderInfo::SetLastDBUpdateTime(int64 i)
+inline void cHeaderInfo::SetLastDBUpdateTime(int64_t i)
 {
     i64_LastDBUpdateTime = i;
 };
@@ -288,11 +288,11 @@ inline const iFCOPropDisplayer* cGenreHeaderInfo::GetPropDisplayer() const
 {
     return mpPropDisplayer;
 }
-inline void cGenreHeaderInfo::SetObjectsScanned(int32 i)
+inline void cGenreHeaderInfo::SetObjectsScanned(int32_t i)
 {
     i32_ObjectsScanned = i;
 };
-inline int32 cGenreHeaderInfo::GetObjectsScanned() const
+inline int32_t cGenreHeaderInfo::GetObjectsScanned() const
 {
     return i32_ObjectsScanned;
 };

--- a/src/tw/systeminfo.cpp
+++ b/src/tw/systeminfo.cpp
@@ -36,8 +36,8 @@
 #include "stdtw.h"
 #include "systeminfo.h"
 
-TSTRING cSystemInfo::mExePath(_T(""));
-bool    cSystemInfo::mbExePathSet(false);
-TSTRING cSystemInfo::mExeDir(_T(""));
-bool    cSystemInfo::mbExeDirSet(false);
-int64   cSystemInfo::mExecuteStartTime(0);
+TSTRING  cSystemInfo::mExePath(_T(""));
+bool     cSystemInfo::mbExePathSet(false);
+TSTRING  cSystemInfo::mExeDir(_T(""));
+bool     cSystemInfo::mbExeDirSet(false);
+int64_t cSystemInfo::mExecuteStartTime(0);

--- a/src/tw/systeminfo.h
+++ b/src/tw/systeminfo.h
@@ -59,7 +59,7 @@ public:
     // these methods get and set the executable's working directory ... it is asserted
     // that SetExeDir() has been called when GetExeDir() is called.
 
-    static int64_t GetExeStartTime();
+    static int64_t  GetExeStartTime();
     static void     SetExeStartTime(const int64_t& time);
     // Get and set the approximate time (time_t format) which the excecutable was started.
     // This will be used for all times having to do with this run of the executable.

--- a/src/tw/systeminfo.h
+++ b/src/tw/systeminfo.h
@@ -50,17 +50,17 @@ public:
     cSystemInfo();
     ~cSystemInfo();
 
-    static TSTRING GetExePath();
-    static void    SetExePath(const TSTRING& path);
+    static TSTRING  GetExePath();
+    static void     SetExePath(const TSTRING& path);
     // Get the full path to this executable
 
-    static TSTRING GetExeDir();
-    static void    SetExeDir(const TSTRING& dir);
+    static TSTRING  GetExeDir();
+    static void     SetExeDir(const TSTRING& dir);
     // these methods get and set the executable's working directory ... it is asserted
     // that SetExeDir() has been called when GetExeDir() is called.
 
-    static int64 GetExeStartTime();
-    static void  SetExeStartTime(const int64& time);
+    static int64_t GetExeStartTime();
+    static void     SetExeStartTime(const int64_t& time);
     // Get and set the approximate time (time_t format) which the excecutable was started.
     // This will be used for all times having to do with this run of the executable.
 
@@ -69,7 +69,7 @@ private:
     static bool    mbExePathSet;
     static TSTRING mExeDir;
     static bool    mbExeDirSet;
-    static int64   mExecuteStartTime;
+    static int64_t mExecuteStartTime;
 };
 
 //-----------------------------------------------------------------------------
@@ -111,13 +111,13 @@ inline void cSystemInfo::SetExeDir(const TSTRING& dir)
     mExeDir = dir;
 }
 
-inline int64 cSystemInfo::GetExeStartTime()
+inline int64_t cSystemInfo::GetExeStartTime()
 {
     ASSERT(mExecuteStartTime != 0);
     return mExecuteStartTime;
 }
 
-inline void cSystemInfo::SetExeStartTime(const int64& time)
+inline void cSystemInfo::SetExeStartTime(const int64_t& time)
 {
     mExecuteStartTime = time;
 }

--- a/src/tw/textdbviewer.cpp
+++ b/src/tw/textdbviewer.cpp
@@ -293,7 +293,7 @@ static void OutputDatabaseHeader(const cFCODbHeader& dbHeader, TOSTREAM* pOut)
     (*pOut) << TSS_GetString(cTW, tw::STR_DB_GENERATED_BY) << util_Encode(dbHeader.GetCreator()) << endl;
 
     TSTRING tstrDummy;
-    int64   i64CreateTime = dbHeader.GetCreationTime();
+    int64_t i64CreateTime = dbHeader.GetCreationTime();
     (*pOut).width(headerColumnWidth);
     (*pOut) << TSS_GetString(cTW, tw::STR_DB_CREATED_ON) << cTWLocale::FormatTime(i64CreateTime, tstrDummy).c_str()
             << endl;
@@ -301,7 +301,7 @@ static void OutputDatabaseHeader(const cFCODbHeader& dbHeader, TOSTREAM* pOut)
     (*pOut).width(headerColumnWidth);
     (*pOut) << TSS_GetString(cTW, tw::STR_DB_LAST_UPDATE);
 
-    int64 i64LastDBUTime = dbHeader.GetLastDBUpdateTime();
+    int64_t i64LastDBUTime = dbHeader.GetLastDBUpdateTime();
     if (i64LastDBUTime == 0)
     {
         (*pOut) << TSS_GetString(cTW, tw::STR_NEVER) << endl << endl;

--- a/src/tw/textreportviewer.cpp
+++ b/src/tw/textreportviewer.cpp
@@ -1133,7 +1133,7 @@ void cTextReportViewer::OutputReportHeader()
 
     // TODO: ( start / end / elapsed ) time
     TSTRING tstrDummy;
-    int64   i64CreateTime = mpHeader->GetCreationTime();
+    int64_t i64CreateTime = mpHeader->GetCreationTime();
     (*mpOut).width(headerColumnWidth);
     (*mpOut) << TSS_GetString(cTW, tw::STR_R_CREATED_ON) << cTWLocale::FormatTime(i64CreateTime, tstrDummy).c_str()
              << endl;
@@ -1141,7 +1141,7 @@ void cTextReportViewer::OutputReportHeader()
     (*mpOut).width(headerColumnWidth);
     (*mpOut) << TSS_GetString(cTW, tw::STR_DB_LAST_UPDATE);
 
-    int64 i64LastDBUTime = mpHeader->GetLastDBUpdateTime();
+    int64_t i64LastDBUTime = mpHeader->GetLastDBUpdateTime();
     if (i64LastDBUTime == 0)
     {
         (*mpOut) << TSS_GetString(cTW, tw::STR_NEVER) << endl << endl;
@@ -1993,7 +1993,7 @@ void cTextReportViewer::GetChar()
 
     // initialize mCurrentChar
     mCurrentCharSize = 0;
-    for (uint32 i = 0; i < sizeof(mCurrentChar); i++)
+    for (uint32_t i = 0; i < sizeof(mCurrentChar); i++)
         mCurrentChar[i] = 0;
 
     static const std::istream::char_type eof = std::char_traits<char>::to_char_type(std::char_traits<char>::eof());

--- a/src/tw/twinit.cpp
+++ b/src/tw/twinit.cpp
@@ -211,7 +211,7 @@ void cTWInit::Init(const TSTRING& strArgv0)
                          // should call this function (cTWInit::Init) on startup
 
     // we require 8-bit bytes for some functionality
-    ASSERT(sizeof(byte) == sizeof(uint8));
+    ASSERT(sizeof(byte) == sizeof(uint8_t));
 
     //
     // set debug level

--- a/src/tw/twutil.cpp
+++ b/src/tw/twutil.cpp
@@ -80,9 +80,9 @@ int _getch(void);
 
 
 // constants
-static const char*  POLICY_FILE_MAGIC_8BYTE = "#POLTXT\n";
-static const char*  CONFIG_FILE_MAGIC_8BYTE = "#CFGTXT\n";
-static const uint32 CURRENT_FIXED_VERSION   = 0x02020000;
+static const char*    POLICY_FILE_MAGIC_8BYTE = "#POLTXT\n";
+static const char*    CONFIG_FILE_MAGIC_8BYTE = "#CFGTXT\n";
+static const uint32_t CURRENT_FIXED_VERSION   = 0x02020000;
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -766,7 +766,7 @@ cTWUtil::CreatePrivateKey(cKeyFile& keyFile, const WCHAR16* usePassphrase, KeyTy
         passphrase.swapbytes();
 #endif
 
-        pPrivateKey = keyFile.GetPrivateKey((int8*)passphrase.data(), passphrase.length() * sizeof(WCHAR16));
+        pPrivateKey = keyFile.GetPrivateKey((int8_t*)passphrase.data(), passphrase.length() * sizeof(WCHAR16));
 
         if (pPrivateKey)
             return pPrivateKey;
@@ -808,7 +808,7 @@ cTWUtil::CreatePrivateKey(cKeyFile& keyFile, const WCHAR16* usePassphrase, KeyTy
         passphrase.swapbytes();
 #endif
 
-        pPrivateKey = keyFile.GetPrivateKey((int8*)passphrase.data(), passphrase.length() * sizeof(WCHAR16));
+        pPrivateKey = keyFile.GetPrivateKey((int8_t*)passphrase.data(), passphrase.length() * sizeof(WCHAR16));
 
         if (pPrivateKey)
             break;
@@ -844,7 +844,7 @@ void cTWUtil::CreatePrivateKey(
         passphrase.swapbytes();
 #endif
 
-        if (proxy.AquireKey(keyFile, (int8*)passphrase.data(), passphrase.length() * sizeof(WCHAR16)))
+        if (proxy.AquireKey(keyFile, (int8_t*)passphrase.data(), passphrase.length() * sizeof(WCHAR16)))
             return;
 
         // if we got here, then a passphrase was provided on the command line that
@@ -884,7 +884,7 @@ void cTWUtil::CreatePrivateKey(
         passphrase.swapbytes();
 #endif
 
-        if (proxy.AquireKey(keyFile, (int8*)passphrase.data(), passphrase.length() * sizeof(WCHAR16)))
+        if (proxy.AquireKey(keyFile, (int8_t*)passphrase.data(), passphrase.length() * sizeof(WCHAR16)))
             return;
 
         // tell the user that they entered the wrong passphrase
@@ -1150,7 +1150,7 @@ TSTRING cTWUtil::GetSystemName()
 
 TSTRING cTWUtil::GetIPAddress()
 {
-    uint32 ipaddress;
+    uint32_t ipaddress;
     if (iFSServices::GetInstance()->GetIPAddress(ipaddress) == false)
         return TSS_GetString(cTW, tw::STR_IP_UNKNOWN);
 

--- a/src/twadmin/keygeneration.cpp
+++ b/src/twadmin/keygeneration.cpp
@@ -46,8 +46,8 @@ struct tGK
 {
     bool         doneFlag;
     int          retValue;
-    int8_t*     passphrase;
-    int32_t     passphraseLen;
+    int8_t*      passphrase;
+    int32_t      passphraseLen;
     const TCHAR* keyPath;
 
     enum ReturnValue

--- a/src/twadmin/keygeneration.cpp
+++ b/src/twadmin/keygeneration.cpp
@@ -46,8 +46,8 @@ struct tGK
 {
     bool         doneFlag;
     int          retValue;
-    int8*        passphrase;
-    int          passphraseLen;
+    int8_t*     passphrase;
+    int32_t     passphraseLen;
     const TCHAR* keyPath;
 
     enum ReturnValue
@@ -146,7 +146,7 @@ bool GenerateKey(const TCHAR* keyPath, wc16_string passphrase, const cElGamalSig
     fflush(stdout);
 
     tGK gk;
-    gk.passphrase    = (int8*)passphrase.data();
+    gk.passphrase    = (int8_t*)passphrase.data();
     gk.passphraseLen = passphrase.length() * sizeof(WCHAR16);
     gk.keyPath       = keyPath;
 
@@ -177,13 +177,13 @@ bool GenerateKey(const TCHAR* keyPath, wc16_string passphrase, const cElGamalSig
 
     keyfile.ReadFile(keyPath);
 
-    ASSERT(keyfile.GetPrivateKey((int8*)passphrase_copy.data(), passphrase_copy.length() * sizeof(WCHAR16)) != 0);
+    ASSERT(keyfile.GetPrivateKey((int8_t*)passphrase_copy.data(), passphrase_copy.length() * sizeof(WCHAR16)) != 0);
     keyfile.ReleasePrivateKey();
 
     //keyfile.WriteFile(_T("tripwire2.key"));
 
     // test memory writing
-    int8 mem[4000];
+    int8_t mem[4000];
     ASSERT(4000 > keyfile.GetWriteLen());
 
     keyfile.WriteMem(mem);
@@ -191,7 +191,7 @@ bool GenerateKey(const TCHAR* keyPath, wc16_string passphrase, const cElGamalSig
     cKeyFile k2;
     k2.ReadMem(mem);
 
-    k2.GetPrivateKey((int8*)passphrase_copy2.data(), passphrase_copy2.length() * sizeof(WCHAR16));
+    k2.GetPrivateKey((int8_t*)passphrase_copy2.data(), passphrase_copy2.length() * sizeof(WCHAR16));
     k2.ReleasePrivateKey();
 #endif
 

--- a/src/twadmin/twadmincl.cpp
+++ b/src/twadmin/twadmincl.cpp
@@ -2062,10 +2062,10 @@ static bool ChangePassphrase(const TCHAR* keyPath, wc16_string passphraseOld, wc
     // we must allocate a BIGENDIAN copy
     // and delete it before we return.
     // auto_ptr does not help (won't work with arrays).
-    size_t passphraseLenOld  = passphraseOld.length() * sizeof(WCHAR16);
-    size_t passphraseLen     = passphrase.length() * sizeof(WCHAR16);
-    int8_t*  passphraseCopyOld = new int8_t[passphraseLenOld];
-    int8_t*  passphraseCopy    = new int8_t[passphraseLen];
+    size_t  passphraseLenOld  = passphraseOld.length() * sizeof(WCHAR16);
+    size_t  passphraseLen     = passphrase.length() * sizeof(WCHAR16);
+    int8_t* passphraseCopyOld = new int8_t[passphraseLenOld];
+    int8_t* passphraseCopy    = new int8_t[passphraseLen];
 #ifdef WORDS_BIGENDIAN
     memcpy(passphraseCopyOld, passphraseOld.data(), passphraseLenOld);
     memcpy(passphraseCopy, passphrase.data(), passphraseLen);

--- a/src/twadmin/twadmincl.cpp
+++ b/src/twadmin/twadmincl.cpp
@@ -81,7 +81,7 @@ void swab(const void* bfrom, void* bto, ssize_t n)
 #endif
 
 // forwards
-static bool NotifyFileType(const cFileHeaderID& id, uint32 version, iUserNotify::VerboseLevel vl);
+static bool NotifyFileType(const cFileHeaderID& id, uint32_t version, iUserNotify::VerboseLevel vl);
 // Calls UserNotify(V_VERBOSE, ...) to print out type of file specified in cFileHeaderID.
 // Returns false if cFileHeaderID not recognized.
 // Used in changing and removing encryption algorithms
@@ -93,14 +93,14 @@ static bool NotifyEncryptionType(cFileHeader::Encoding encoding, iUserNotify::Ve
 
 // error implementations
 
-eTWACreateCfgMissingSitekey::eTWACreateCfgMissingSitekey(const TSTRING& msg, uint32 flags) : eTWA(TSTRING(), flags)
+eTWACreateCfgMissingSitekey::eTWACreateCfgMissingSitekey(const TSTRING& msg, uint32_t flags) : eTWA(TSTRING(), flags)
 {
     mMsg = TSS_GetString(cTWAdmin, twadmin::STR_ERR2_CREATE_CFG_MISSING_KEYFILE) + msg;
 }
 
 eTWACreateCfgSitekeyMismatch::eTWACreateCfgSitekeyMismatch(const TSTRING& specifiedKeyfile,
                                                            const TSTRING& configKeyfile,
-                                                           uint32         flags)
+                                                           uint32_t       flags)
     : eTWA(TSTRING(), flags)
 {
     mMsg = TSS_GetString(cTWAdmin, twadmin::STR_ERR2_CREATE_CFG_SITEKEY_MISMATCH1);
@@ -2064,8 +2064,8 @@ static bool ChangePassphrase(const TCHAR* keyPath, wc16_string passphraseOld, wc
     // auto_ptr does not help (won't work with arrays).
     size_t passphraseLenOld  = passphraseOld.length() * sizeof(WCHAR16);
     size_t passphraseLen     = passphrase.length() * sizeof(WCHAR16);
-    int8*  passphraseCopyOld = new int8[passphraseLenOld];
-    int8*  passphraseCopy    = new int8[passphraseLen];
+    int8_t*  passphraseCopyOld = new int8_t[passphraseLenOld];
+    int8_t*  passphraseCopy    = new int8_t[passphraseLen];
 #ifdef WORDS_BIGENDIAN
     memcpy(passphraseCopyOld, passphraseOld.data(), passphraseLenOld);
     memcpy(passphraseCopy, passphrase.data(), passphraseLen);
@@ -2878,7 +2878,7 @@ iTWAMode* cTWAdminCmdLine::GetMode(int argc, const TCHAR* const* argv)
 // Calls UserNotify(V_VERBOSE, ...) to print out type of file specified in cFileHeaderID.
 // Returns false if cFileHeaderID not recognized.
 // Used in changing and removing encryption algorithms
-static bool NotifyFileType(const cFileHeaderID& id, uint32 version, iUserNotify::VerboseLevel vl)
+static bool NotifyFileType(const cFileHeaderID& id, uint32_t version, iUserNotify::VerboseLevel vl)
 {
     if (id == cFCODatabaseFile::GetFileHeaderID())
     {

--- a/src/twadmin/twadmincl.h
+++ b/src/twadmin/twadmincl.h
@@ -52,18 +52,18 @@ TSS_EXCEPTION(eTWADecrypt, eTWA)
 TSS_EXCEPTION(eTWADecryptCorrupt, eTWA)
 
 TSS_BEGIN_EXCEPTION_NO_CTOR(eTWAEncryptionChange, eTWA)
-eTWAEncryptionChange(const TSTRING& strMsg1, const TSTRING& strMsg2 = _T(""), uint32 flags = 0)
+eTWAEncryptionChange(const TSTRING& strMsg1, const TSTRING& strMsg2 = _T(""), uint32_t flags = 0)
     : eTWA(strMsg1 + strMsg2, flags)
 {
 }
 TSS_END_EXCEPTION();
 
 TSS_BEGIN_EXCEPTION_NO_CTOR(eTWACreateCfgMissingSitekey, eTWA)
-eTWACreateCfgMissingSitekey(const TSTRING& msg, uint32 flags = 0);
+eTWACreateCfgMissingSitekey(const TSTRING& msg, uint32_t flags = 0);
 TSS_END_EXCEPTION();
 
 TSS_BEGIN_EXCEPTION_NO_CTOR(eTWACreateCfgSitekeyMismatch, eTWA)
-eTWACreateCfgSitekeyMismatch(const TSTRING& specifiedKeyfile, const TSTRING& configKeyfile, uint32 flags = 0);
+eTWACreateCfgSitekeyMismatch(const TSTRING& specifiedKeyfile, const TSTRING& configKeyfile, uint32_t flags = 0);
 TSS_END_EXCEPTION();
 
 

--- a/src/twcrypto/crypto.cpp
+++ b/src/twcrypto/crypto.cpp
@@ -57,8 +57,8 @@
 #include <unistd.h>
 #include <fcntl.h>
 
-const uint32 EL_GAMAL_SIG_PUBLIC_MAGIC_NUM  = 0x7ae2c945;
-const uint32 EL_GAMAL_SIG_PRIVATE_MAGIC_NUM = 0x0d0ffa12;
+const uint32_t EL_GAMAL_SIG_PUBLIC_MAGIC_NUM  = 0x7ae2c945;
+const uint32_t EL_GAMAL_SIG_PRIVATE_MAGIC_NUM = 0x0d0ffa12;
 
 ///////////////////////////////////////////////////////////////////////////////
 // macros for reading and writing integers
@@ -68,7 +68,7 @@ const uint32 EL_GAMAL_SIG_PRIVATE_MAGIC_NUM = 0x0d0ffa12;
     ASSERT(len >= 0 && len < 9000);            \
     i32 = tw_htonl(len);                       \
     memcpy(pOut, &i32, sizeof(i32));           \
-    pOut += sizeof(int32);                     \
+    pOut += sizeof(int32_t);                     \
     I.Encode(pOut, len, Integer::UNSIGNED);    \
     pOut += len;
 
@@ -76,7 +76,7 @@ const uint32 EL_GAMAL_SIG_PRIVATE_MAGIC_NUM = 0x0d0ffa12;
     memcpy(&i32, pIn, sizeof(i32));        \
     len = tw_ntohl(i32);                   \
     ASSERT(len >= 0 && len < 9000);        \
-    pIn += sizeof(int32);                  \
+    pIn += sizeof(int32_t);                  \
     I.Decode(pIn, len, Integer::UNSIGNED); \
     pIn += len;
 
@@ -255,7 +255,7 @@ void cTripleDES::ProcessBlock(const void* indata, void* outdata)
 class cRSAPrivateKey_i
 {
 public:
-    int16          mKeyLength;
+    int16_t        mKeyLength;
     RSAPrivateKey* mpKey;
 };
 
@@ -270,15 +270,15 @@ cRSAPrivateKey::cRSAPrivateKey(void* pDataStream)
 {
     mpData = new cRSAPrivateKey_i;
 
-    int32 len;
-    int32 i32;
-    int16 i16;
+    int32_t len;
+    int32_t i32;
+    int16_t i16;
 
     uint8_t* pIn = (uint8_t*)pDataStream;
 
     memcpy(&i16, pIn, sizeof(i16));
     mpData->mKeyLength = tw_ntohs(i16);
-    pIn += sizeof(int16);
+    pIn += sizeof(int16_t);
 
     Integer n, e, d, p, q, dp, dq, u;
 
@@ -316,16 +316,16 @@ int cRSAPrivateKey::GetWriteLen() const
     ASSERT(mpData->mpKey->GetTrapdoorFunction().GetParameterDQ().IsPositive());
     ASSERT(mpData->mpKey->GetTrapdoorFunction().GetParameterU().IsPositive());
 
-    int len = sizeof(int16) + mpData->mpKey->GetTrapdoorFunction().GetModulus().MinEncodedSize(Integer::UNSIGNED) +
-              sizeof(int32) + mpData->mpKey->GetTrapdoorFunction().GetExponent().MinEncodedSize(Integer::UNSIGNED) +
-              sizeof(int32) + mpData->mpKey->GetTrapdoorFunction().GetPrime1().MinEncodedSize(Integer::UNSIGNED) +
-              sizeof(int32) + mpData->mpKey->GetTrapdoorFunction().GetPrime2().MinEncodedSize(Integer::UNSIGNED) +
-              sizeof(int32) +
+    int len = sizeof(int16_t) + mpData->mpKey->GetTrapdoorFunction().GetModulus().MinEncodedSize(Integer::UNSIGNED) +
+              sizeof(int32_t) + mpData->mpKey->GetTrapdoorFunction().GetExponent().MinEncodedSize(Integer::UNSIGNED) +
+              sizeof(int32_t) + mpData->mpKey->GetTrapdoorFunction().GetPrime1().MinEncodedSize(Integer::UNSIGNED) +
+              sizeof(int32_t) + mpData->mpKey->GetTrapdoorFunction().GetPrime2().MinEncodedSize(Integer::UNSIGNED) +
+              sizeof(int32_t) +
               mpData->mpKey->GetTrapdoorFunction().GetDecryptionExponent().MinEncodedSize(Integer::UNSIGNED) +
-              sizeof(int32) + mpData->mpKey->GetTrapdoorFunction().GetParameterDP().MinEncodedSize(Integer::UNSIGNED) +
-              sizeof(int32) + mpData->mpKey->GetTrapdoorFunction().GetParameterDQ().MinEncodedSize(Integer::UNSIGNED) +
-              sizeof(int32) + mpData->mpKey->GetTrapdoorFunction().GetParameterU().MinEncodedSize(Integer::UNSIGNED) +
-              sizeof(int32);
+              sizeof(int32_t) + mpData->mpKey->GetTrapdoorFunction().GetParameterDP().MinEncodedSize(Integer::UNSIGNED) +
+              sizeof(int32_t) + mpData->mpKey->GetTrapdoorFunction().GetParameterDQ().MinEncodedSize(Integer::UNSIGNED) +
+              sizeof(int32_t) + mpData->mpKey->GetTrapdoorFunction().GetParameterU().MinEncodedSize(Integer::UNSIGNED) +
+              sizeof(int32_t);
 
     return len;
 }
@@ -344,12 +344,12 @@ void cRSAPrivateKey::Write(void* pDataStream) const
     ASSERT(mpData->mpKey->GetTrapdoorFunction().GetParameterU().IsPositive());
 
     uint8_t* pOut = (uint8_t*)pDataStream;
-    int16 i16;
-    int32 i32;
+    int16_t i16;
+    int32_t i32;
 
     i16 = tw_htons(mpData->mKeyLength);
     memcpy(pOut, &i16, sizeof(i16));
-    pOut += sizeof(int16);
+    pOut += sizeof(int16_t);
 
     Integer n, e, d, p, q, dp, dq, u;
 
@@ -362,13 +362,13 @@ void cRSAPrivateKey::Write(void* pDataStream) const
     dq = mpData->mpKey->GetTrapdoorFunction().GetParameterDQ();
     u  = mpData->mpKey->GetTrapdoorFunction().GetParameterU();
 
-    int32 len;
+    int32_t len;
 
 #    define WRITE_INTEGER(I)                       \
         len = I.MinEncodedSize(Integer::UNSIGNED); \
         i32 = tw_htonl(len);                       \
         memcpy(pOut, &i32, sizeof(i32));           \
-        pOut += sizeof(int32);                     \
+        pOut += sizeof(int32_t);                     \
         I.Encode(pOut, len, Integer::UNSIGNED);    \
         pOut += len;
 
@@ -387,7 +387,7 @@ void cRSAPrivateKey::Write(void* pDataStream) const
 class cRSAPublicKey_i
 {
 public:
-    int16         mKeyLength;
+    int16_t       mKeyLength;
     RSAPublicKey* mpKey;
 };
 
@@ -403,15 +403,15 @@ cRSAPublicKey::cRSAPublicKey(void* pDataStream)
     mpData = new cRSAPublicKey_i;
 
     Integer n, e;
-    int32   len;
-    int16   i16;
-    int32   i32;
+    int32_t   len;
+    int16_t   i16;
+    int32_t   i32;
 
     uint8_t* pIn = (uint8_t*)pDataStream;
 
     memcpy(&i16, pIn, sizeof(i16));
     mpData->mKeyLength = tw_ntohs(i16);
-    pIn += sizeof(int16);
+    pIn += sizeof(int16_t);
 
     READ_INTEGER(n);
     READ_INTEGER(e);
@@ -449,9 +449,9 @@ int cRSAPublicKey::GetWriteLen() const
     ASSERT(mpData->mpKey->GetTrapdoorFunction().GetModulus().IsPositive());
     ASSERT(mpData->mpKey->GetTrapdoorFunction().GetExponent().IsPositive());
 
-    int len = sizeof(int16) + mpData->mpKey->GetTrapdoorFunction().GetModulus().MinEncodedSize(Integer::UNSIGNED) +
-              sizeof(int32) + mpData->mpKey->GetTrapdoorFunction().GetExponent().MinEncodedSize(Integer::UNSIGNED) +
-              sizeof(int32);
+    int len = sizeof(int16_t) + mpData->mpKey->GetTrapdoorFunction().GetModulus().MinEncodedSize(Integer::UNSIGNED) +
+              sizeof(int32_t) + mpData->mpKey->GetTrapdoorFunction().GetExponent().MinEncodedSize(Integer::UNSIGNED) +
+              sizeof(int32_t);
 
     return len;
 }
@@ -463,20 +463,20 @@ void cRSAPublicKey::Write(void* pDataStream) const
     ASSERT(mpData->mpKey->GetTrapdoorFunction().GetModulus().IsPositive());
     ASSERT(mpData->mpKey->GetTrapdoorFunction().GetExponent().IsPositive());
 
-    int16 i16;
-    int32 i32;
+    int16_t i16;
+    int32_t i32;
     uint8_t* pOut = (uint8_t*)pDataStream;
 
     i16 = tw_htons(mpData->mKeyLength);
     memcpy(pOut, &i16, sizeof(i16));
-    pOut += sizeof(int16);
+    pOut += sizeof(int16_t);
 
     Integer n, e;
 
     n = mpData->mpKey->GetTrapdoorFunction().GetModulus();
     e = mpData->mpKey->GetTrapdoorFunction().GetExponent();
 
-    int32 len;
+    int32_t len;
 
     WRITE_INTEGER(n);
     WRITE_INTEGER(e);
@@ -553,8 +553,8 @@ void cRSA::Init(KeySize keysize)
     // Create a random seed and a key
     uint8_t seed[MD5::DATASIZE];
     uint8_t deskey[TripleDES_Encryption::KEYLENGTH];
-    RandomizeBytes((int8*)seed, MD5::DATASIZE);
-    RandomizeBytes((int8*)deskey, TripleDES_Encryption::KEYLENGTH);
+    RandomizeBytes((int8_t*)seed, MD5::DATASIZE);
+    RandomizeBytes((int8_t*)deskey, TripleDES_Encryption::KEYLENGTH);
 
     mpData->mpRNG = new X917RNG(new TripleDES_Encryption(deskey), seed);
 }
@@ -720,7 +720,7 @@ void cRSA::GenerateKeys(cRSAPrivateKey*& retPrivate, cRSAPublicKey*& retPublic)
 class cElGamalSigPrivateKey_i
 {
 public:
-    int16                 mKeyLength;
+    int16_t               mKeyLength;
     ElGamalSigPrivateKey* mpKey;
 };
 
@@ -735,20 +735,20 @@ cElGamalSigPrivateKey::cElGamalSigPrivateKey(void* pDataStream)
 {
     mpData = new cElGamalSigPrivateKey_i;
 
-    int32  len;
-    int32  i32;
-    int16  i16;
-    uint32 magicNum;
+    int32_t  len;
+    int32_t  i32;
+    int16_t  i16;
+    uint32_t magicNum;
 
     uint8_t* pIn = (uint8_t*)pDataStream;
 
     memcpy(&i16, pIn, sizeof(i16));
     mpData->mKeyLength = tw_ntohs(i16);
-    pIn += sizeof(int16);
+    pIn += sizeof(int16_t);
 
     memcpy(&i32, pIn, sizeof(i32));
     magicNum = tw_ntohl(i32);
-    pIn += sizeof(int32);
+    pIn += sizeof(int32_t);
 
     if (magicNum != EL_GAMAL_SIG_PRIVATE_MAGIC_NUM)
         ThrowAndAssert(eArchiveOpen());
@@ -783,11 +783,11 @@ int cElGamalSigPrivateKey::GetWriteLen() const
     ASSERT(mpData->mpKey->GetParameterY().IsPositive());
     ASSERT(mpData->mpKey->GetParameterX().IsPositive());
 
-    int len = sizeof(int16) + sizeof(int32) + mpData->mpKey->GetPrime().MinEncodedSize(Integer::UNSIGNED) +
-              sizeof(int32) + mpData->mpKey->GetParameterQ().MinEncodedSize(Integer::UNSIGNED) + sizeof(int32) +
-              mpData->mpKey->GetParameterG().MinEncodedSize(Integer::UNSIGNED) + sizeof(int32) +
-              mpData->mpKey->GetParameterY().MinEncodedSize(Integer::UNSIGNED) + sizeof(int32) +
-              mpData->mpKey->GetParameterX().MinEncodedSize(Integer::UNSIGNED) + sizeof(int32);
+    int len = sizeof(int16_t) + sizeof(int32_t) + mpData->mpKey->GetPrime().MinEncodedSize(Integer::UNSIGNED) +
+              sizeof(int32_t) + mpData->mpKey->GetParameterQ().MinEncodedSize(Integer::UNSIGNED) + sizeof(int32_t) +
+              mpData->mpKey->GetParameterG().MinEncodedSize(Integer::UNSIGNED) + sizeof(int32_t) +
+              mpData->mpKey->GetParameterY().MinEncodedSize(Integer::UNSIGNED) + sizeof(int32_t) +
+              mpData->mpKey->GetParameterX().MinEncodedSize(Integer::UNSIGNED) + sizeof(int32_t);
 
     return len;
 }
@@ -803,16 +803,16 @@ void cElGamalSigPrivateKey::Write(void* pDataStream) const
     ASSERT(mpData->mpKey->GetParameterX().IsPositive());
 
     uint8_t* pOut = (uint8_t*)pDataStream;
-    int16 i16;
-    int32 i32;
+    int16_t i16;
+    int32_t i32;
 
     i16 = tw_htons(mpData->mKeyLength);
     memcpy(pOut, &i16, sizeof(i16));
-    pOut += sizeof(int16);
+    pOut += sizeof(int16_t);
 
     i32 = tw_htonl(EL_GAMAL_SIG_PRIVATE_MAGIC_NUM);
     memcpy(pOut, &i32, sizeof(i32));
-    pOut += sizeof(int32);
+    pOut += sizeof(int32_t);
 
     Integer p, q, g, y, x;
 
@@ -822,7 +822,7 @@ void cElGamalSigPrivateKey::Write(void* pDataStream) const
     y = mpData->mpKey->GetParameterY();
     x = mpData->mpKey->GetParameterX();
 
-    int32 len;
+    int32_t len;
 
     WRITE_INTEGER(p);
     WRITE_INTEGER(q);
@@ -836,7 +836,7 @@ void cElGamalSigPrivateKey::Write(void* pDataStream) const
 class cElGamalSigPublicKey_i
 {
 public:
-    int16                mKeyLength;
+    int16_t              mKeyLength;
     ElGamalSigPublicKey* mpKey;
 };
 
@@ -851,21 +851,21 @@ cElGamalSigPublicKey::cElGamalSigPublicKey(void* pDataStream)
 {
     mpData = new cElGamalSigPublicKey_i;
 
-    Integer p, q, g, y;
-    int32   len;
-    int16   i16;
-    int32   i32;
-    uint32  magicNum;
+    Integer   p, q, g, y;
+    int32_t   len;
+    int16_t   i16;
+    int32_t   i32;
+    uint32_t  magicNum;
 
     uint8_t* pIn = (uint8_t*)pDataStream;
 
     memcpy(&i16, pIn, sizeof(i16));
     mpData->mKeyLength = tw_ntohs(i16);
-    pIn += sizeof(int16);
+    pIn += sizeof(int16_t);
 
     memcpy(&i32, pIn, sizeof(i32));
     magicNum = tw_ntohl(i32);
-    pIn += sizeof(int32);
+    pIn += sizeof(int32_t);
 
     if (magicNum != EL_GAMAL_SIG_PUBLIC_MAGIC_NUM)
         ThrowAndAssert(eArchiveOpen());
@@ -910,10 +910,10 @@ int cElGamalSigPublicKey::GetWriteLen() const
     ASSERT(mpData->mpKey->GetParameterG().IsPositive());
     ASSERT(mpData->mpKey->GetParameterY().IsPositive());
 
-    int len = sizeof(int16) + sizeof(int32) + mpData->mpKey->GetPrime().MinEncodedSize(Integer::UNSIGNED) +
-              sizeof(int32) + mpData->mpKey->GetParameterQ().MinEncodedSize(Integer::UNSIGNED) + sizeof(int32) +
-              mpData->mpKey->GetParameterG().MinEncodedSize(Integer::UNSIGNED) + sizeof(int32) +
-              mpData->mpKey->GetParameterY().MinEncodedSize(Integer::UNSIGNED) + sizeof(int32);
+    int len = sizeof(int16_t) + sizeof(int32_t) + mpData->mpKey->GetPrime().MinEncodedSize(Integer::UNSIGNED) +
+              sizeof(int32_t) + mpData->mpKey->GetParameterQ().MinEncodedSize(Integer::UNSIGNED) + sizeof(int32_t) +
+              mpData->mpKey->GetParameterG().MinEncodedSize(Integer::UNSIGNED) + sizeof(int32_t) +
+              mpData->mpKey->GetParameterY().MinEncodedSize(Integer::UNSIGNED) + sizeof(int32_t);
 
     return len;
 }
@@ -928,16 +928,16 @@ void cElGamalSigPublicKey::Write(void* pDataStream) const
     ASSERT(mpData->mpKey->GetParameterY().IsPositive());
 
     uint8_t* pOut = (uint8_t*)pDataStream;
-    int16 i16;
-    int32 i32;
+    int16_t i16;
+    int32_t i32;
 
     i16 = tw_htons(mpData->mKeyLength);
     memcpy(pOut, &i16, sizeof(i16));
-    pOut += sizeof(int16);
+    pOut += sizeof(int16_t);
 
     i32 = tw_htonl(EL_GAMAL_SIG_PUBLIC_MAGIC_NUM);
     memcpy(pOut, &i32, sizeof(i32));
-    pOut += sizeof(int32);
+    pOut += sizeof(int32_t);
 
     Integer p, q, g, y;
 
@@ -946,7 +946,7 @@ void cElGamalSigPublicKey::Write(void* pDataStream) const
     g = mpData->mpKey->GetParameterG();
     y = mpData->mpKey->GetParameterY();
 
-    int32 len;
+    int32_t len;
 
     WRITE_INTEGER(p);
     WRITE_INTEGER(q);
@@ -1040,8 +1040,8 @@ void cElGamalSig::Init(KeySize keysize)
     // Create a random seed and a key
     uint8_t seed[SHA::DATASIZE];
     uint8_t deskey[TripleDES_Encryption::KEYLENGTH];
-    RandomizeBytes((int8*)seed, SHA::DATASIZE);
-    RandomizeBytes((int8*)deskey, TripleDES_Encryption::KEYLENGTH);
+    RandomizeBytes((int8_t*)seed,   SHA::DATASIZE);
+    RandomizeBytes((int8_t*)deskey, TripleDES_Encryption::KEYLENGTH);
 
     mpData->mpRNG = new X917RNG(new TripleDES_Encryption(deskey), seed);
 }
@@ -1095,7 +1095,7 @@ void cElGamalSig::ProcessBlock(const void* indata, void* outdata)
     ASSERT(mpData != 0);
     ASSERT(mpData->mpPrivateKey != 0 || mpData->mpPublicKey != 0);
 
-    int8 shaSig[SHA::DIGESTSIZE];
+    int8_t shaSig[SHA::DIGESTSIZE];
 
     if (mpData->mpPrivateKey == 0 && mpData->mpPublicKey == 0)
         ThrowAndAssert(eInternal(_T("Signature Key length mismatch.")));
@@ -1111,7 +1111,7 @@ void cElGamalSig::ProcessBlock(const void* indata, void* outdata)
 
         mpData->mSHA.CalculateDigest((uint8_t*)shaSig, (uint8_t*)outdata, PLAIN_BLOCK_SIZE);
 
-        RandomizeBytes((int8*)outdata + PLAIN_BLOCK_SIZE, GetBlockSizeCipher() - PLAIN_BLOCK_SIZE);
+        RandomizeBytes((int8_t*)outdata + PLAIN_BLOCK_SIZE, GetBlockSizeCipher() - PLAIN_BLOCK_SIZE);
         mpData->mpPrivateKey->mpData->mpKey->Sign(
             *mpData->mpRNG, (const uint8_t*)shaSig, SHA::DIGESTSIZE, (uint8_t*)outdata + PLAIN_BLOCK_SIZE);
 
@@ -1171,11 +1171,11 @@ void cElGamalSig::GenerateKeys(cElGamalSigPrivateKey*& retPrivate, cElGamalSigPu
 
     retPrivate                     = new cElGamalSigPrivateKey();
     retPrivate->mpData->mpKey      = pNewPrivateKey;
-    retPrivate->mpData->mKeyLength = (int16)mpData->mKeyBits;
+    retPrivate->mpData->mKeyLength = (int16_t)mpData->mKeyBits;
 
     retPublic                     = new cElGamalSigPublicKey();
     retPublic->mpData->mpKey      = pNewPublicKey;
-    retPublic->mpData->mKeyLength = (int16)mpData->mKeyBits;
+    retPublic->mpData->mKeyLength = (int16_t)mpData->mKeyBits;
 
 #ifdef DEBUG
     int l;
@@ -1248,7 +1248,7 @@ cHashedKey192::~cHashedKey192()
 /////////////////////////////////////////////////////////
 
 #if USE_DEV_URANDOM
-static bool randomize_by_device(const char* device_name, int8* destbuf, int len)
+static bool randomize_by_device(const char* device_name, int8_t* destbuf, int len)
 {
     static int rng_device = -1;
 
@@ -1257,7 +1257,7 @@ static bool randomize_by_device(const char* device_name, int8* destbuf, int len)
 
     if (rng_device >= 0)
     {
-        int uint8_ts_read = read(rng_device, destbuf, len);
+        int bytes_read = read(rng_device, destbuf, len);
         if (bytes_read == len)
             return true;
     }
@@ -1271,7 +1271,7 @@ static bool gRandomizeBytesSeeded = false;
 ///////////////////////////////////////////////////////////////////////////////
 // void RandomizeBytes(byte* destbuf, int len) -- Fill a buffer with random bytes
 
-void RandomizeBytes(int8* destbuf, int len)
+void RandomizeBytes(int8_t* destbuf, int len)
 {
 #if USE_DEV_URANDOM
     if (randomize_by_device("/dev/urandom", destbuf, len))
@@ -1301,8 +1301,8 @@ void RandomizeBytes(int8* destbuf, int len)
         gRandomizeBytesSeeded = true;
     }
 
-    int i;
-    for (i = 0; i < len; ++i)
-        destbuf[i] = (uint8_t)((rand() * 256 / RAND_MAX) ^ 0xdc); // 0xdc came from random.org
+    for (int i = 0; i < len; ++i) {
+        destbuf[i] = (int8_t)((rand() * 256 / RAND_MAX) ^ 0xdc); // 0xdc came from random.org
+    }
 #endif
 }

--- a/src/twcrypto/crypto.h
+++ b/src/twcrypto/crypto.h
@@ -353,10 +353,10 @@ public:
     cHashedKey128(void* pData, int dataLen);
     ~cHashedKey128();
 
-    const int8* GetKey() const;
+    const int8_t* GetKey() const;
 
     static int GetWriteLen();
-    void       Write(void* pDataStream);
+    void Write(void* pDataStream);
 
 protected:
     enum
@@ -365,10 +365,10 @@ protected:
         BUFSIZE = 20
     };
 
-    int8 mKey[BUFSIZE];
+    int8_t mKey[BUFSIZE];
 };
 
-inline const int8* cHashedKey128::GetKey() const
+inline const int8_t* cHashedKey128::GetKey() const
 {
     return mKey;
 }
@@ -390,13 +390,13 @@ class cHashedKey192
 {
 public:
     explicit cHashedKey192(const TSTRING& data);
-    cHashedKey192(void* pData, int dataLen);
+    cHashedKey192(void* pData, int32_t dataLen);
     ~cHashedKey192();
 
-    const int8* GetKey() const;
+    const int8_t* GetKey() const;
 
     static int GetWriteLen();
-    void       Write(void* pDataStream);
+    void Write(void* pDataStream);
 
 protected:
     enum
@@ -404,10 +404,10 @@ protected:
         KEYLEN = 24
     };
 
-    int8 mKey[KEYLEN];
+    int8_t mKey[KEYLEN];
 };
 
-inline const int8* cHashedKey192::GetKey() const
+inline const int8_t* cHashedKey192::GetKey() const
 {
     return mKey;
 }
@@ -425,6 +425,6 @@ inline void cHashedKey192::Write(void* pDataStream)
 ///////////////////////////////////////////////////////////////////////////////
 // void RandomizeBytes(byte* destbuf, int len) -- Fill a buffer with random bytes
 
-void RandomizeBytes(int8* destbuf, int len);
+void RandomizeBytes(int8_t* destbuf, int len);
 
 #endif // __CRYPTO_H

--- a/src/twcrypto/cryptoarchive.cpp
+++ b/src/twcrypto/cryptoarchive.cpp
@@ -79,7 +79,7 @@ private:
     iCipher*  mpCipher;
 
     // buffer to cache bytes in
-    int8* mpBuffer;
+    int8_t* mpBuffer;
     int   mBufferLen;
     int   mBufferUsed;
 };
@@ -98,7 +98,7 @@ private:
     iCipher*  mpCipher;
 
     // buffer to cache bytes in
-    int8* mpBuffer;
+    int8_t* mpBuffer;
     int   mBufferLen;
     int   mBufferUsed;
 };
@@ -284,7 +284,7 @@ void cCryptoSink::Put(const uint8_t* inString, unsigned int length)
     {
         // this is the first write
         mBufferLen  = mpCipher->GetBlockSizePlain();
-        mpBuffer    = new int8[mBufferLen];
+        mpBuffer    = new int8_t[mBufferLen];
         mBufferUsed = 0;
     }
 
@@ -299,14 +299,14 @@ void cCryptoSink::Put(const uint8_t* inString, unsigned int length)
         if (bytesToCopy > nLength - i)
             bytesToCopy = nLength - i;
 
-        memcpy(mpBuffer + mBufferUsed, (int8*)inString + i, bytesToCopy);
+        memcpy(mpBuffer + mBufferUsed, (int8_t*)inString + i, bytesToCopy);
         mBufferUsed += bytesToCopy;
 
         if (mBufferUsed >= mBufferLen)
         {
             ASSERT(mBufferUsed == mBufferLen); // should be if our math is right
 
-            int8* pTmp = new int8[mpCipher->GetBlockSizeCipher()];
+            int8_t* pTmp = new int8_t[mpCipher->GetBlockSizeCipher()];
             mpCipher->ProcessBlock(mpBuffer, pTmp);
 
             mpDestArchive->WriteBlob(pTmp, mpCipher->GetBlockSizeCipher());
@@ -328,7 +328,7 @@ void cCryptoSink::InputFinished()
         ASSERT(mBufferLen - mBufferUsed > 0); // should be, or the buffer should have already been written
         RandomizeBytes(mpBuffer + mBufferUsed, mBufferLen - mBufferUsed);
 
-        int8* pTmp = new int8[mpCipher->GetBlockSizeCipher()];
+        int8_t* pTmp = new int8_t[mpCipher->GetBlockSizeCipher()];
         mpCipher->ProcessBlock(mpBuffer, pTmp);
 
         mpDestArchive->WriteBlob(pTmp, mpCipher->GetBlockSizeCipher());
@@ -366,7 +366,7 @@ unsigned int cCryptoSource::Pump(unsigned int size)
     {
         // first time this has been called
         mBufferLen  = mpCipher->GetBlockSizePlain();
-        mpBuffer    = new int8[mBufferLen];
+        mpBuffer    = new int8_t[mBufferLen];
         mBufferUsed = mBufferLen;
     }
 
@@ -381,7 +381,7 @@ unsigned int cCryptoSource::Pump(unsigned int size)
         {
             ASSERT(mBufferUsed == mBufferLen); // should be if our math is right
 
-            int8* pTmp = new int8[mpCipher->GetBlockSizeCipher()];
+            int8_t* pTmp = new int8_t[mpCipher->GetBlockSizeCipher()];
 
             int l = mpSrcArchive->ReadBlob(pTmp, mpCipher->GetBlockSizeCipher());
             if (l != mpCipher->GetBlockSizeCipher())
@@ -503,8 +503,8 @@ void cRSAArchive::SetWrite(cArchive* pDestArchive, const cRSAPublicKey* pPublicK
 
     // Create a random number and encode using public key
     cRSA  rsa(*mpPublicKey);
-    int8* key          = new int8[rsa.GetBlockSizePlain()];
-    int8* encryptedKey = new int8[rsa.GetBlockSizeCipher()];
+    int8_t* key          = new int8_t[rsa.GetBlockSizePlain()];
+    int8_t* encryptedKey = new int8_t[rsa.GetBlockSizeCipher()];
 
     RandomizeBytes(key, rsa.GetBlockSizePlain());
     rsa.SetEncrypting(mpPublicKey);
@@ -535,8 +535,8 @@ void cRSAArchive::SetWrite(cArchive* pDestArchive, const cRSAPrivateKey* pPrivat
 
     // Create a random number and encode using public key
     cRSA  rsa(*mpPrivateKey);
-    int8* key          = new int8[rsa.GetBlockSizePlain()];
-    int8* encryptedKey = new int8[rsa.GetBlockSizeCipher()];
+    int8_t* key          = new int8_t[rsa.GetBlockSizePlain()];
+    int8_t* encryptedKey = new int8_t[rsa.GetBlockSizeCipher()];
 
     RandomizeBytes(key, rsa.GetBlockSizePlain());
     rsa.SetSigning(mpPrivateKey);
@@ -578,8 +578,8 @@ void cRSAArchive::SetRead(cArchive* pSrcArchive, const cRSAPublicKey* pPublicKey
     mpPrivateKey = 0;
 
     cRSA  rsa(*mpPublicKey);
-    int8* key          = new int8[rsa.GetBlockSizePlain()];
-    int8* encryptedKey = new int8[rsa.GetBlockSizeCipher()];
+    int8_t* key          = new int8_t[rsa.GetBlockSizePlain()];
+    int8_t* encryptedKey = new int8_t[rsa.GetBlockSizeCipher()];
 
     mpArchive->ReadBlob(encryptedKey, rsa.GetBlockSizeCipher());
     rsa.SetVerifying(mpPublicKey);
@@ -608,8 +608,8 @@ void cRSAArchive::SetRead(cArchive* pSrcArchive, const cRSAPrivateKey* pPrivateK
     mpPublicKey  = 0;
 
     cRSA  rsa(*mpPrivateKey);
-    int8* key          = new int8[rsa.GetBlockSizePlain()];
-    int8* encryptedKey = new int8[rsa.GetBlockSizeCipher()];
+    int8_t* key          = new int8_t[rsa.GetBlockSizePlain()];
+    int8_t* encryptedKey = new int8_t[rsa.GetBlockSizeCipher()];
 
     mpArchive->ReadBlob(encryptedKey, rsa.GetBlockSizeCipher());
     rsa.SetDecrypting(mpPrivateKey);

--- a/src/twcrypto/keyfile.cpp
+++ b/src/twcrypto/keyfile.cpp
@@ -44,9 +44,9 @@
 // A magic number to identify key files
 // I just picked this at random (I took the current time (14:34) squared it,
 // converted it to hex and xor'ed with 0xffffffff, just in case you are wondering) - dmb
-const uint32        KEY_MAGIC_NUMBER      = 0xffe09f5b;
-static const uint32 CURRENT_FIXED_VERSION = 0x02020000;
-static const uint32 TW_21_VERSION         = 0x02010000;
+const uint32_t        KEY_MAGIC_NUMBER      = 0xffe09f5b;
+static const uint32_t CURRENT_FIXED_VERSION = 0x02020000;
+static const uint32_t TW_21_VERSION         = 0x02010000;
 
 ///////////////////////////////////////////////////////////////////////////////
 // class cKeyFile
@@ -121,7 +121,7 @@ void cKeyFile::ReadFile(const TCHAR* filename) // throw eKeyFile()
 {
     ReleaseMem();
 
-    int16 len;
+    int16_t len;
 
     try
     {
@@ -135,7 +135,7 @@ void cKeyFile::ReadFile(const TCHAR* filename) // throw eKeyFile()
             cSerializerImpl fhSer(inFile, cSerializerImpl::S_READ, filename);
             fileHeader.Read(&fhSer);
         }
-        catch (eError&)
+        catch (const eError&)
         {
             throw eKeyFileInvalidFmt();
         }
@@ -165,7 +165,7 @@ void cKeyFile::ReadFile(const TCHAR* filename) // throw eKeyFile()
             throw eKeyFileInvalidFmt();
         }
 
-        int8* publicMem = new int8[len];
+        int8_t* publicMem = new int8_t[len];
         if (inFile.ReadBlob(publicMem, len) != len)
         {
             ASSERT(false);
@@ -177,7 +177,7 @@ void cKeyFile::ReadFile(const TCHAR* filename) // throw eKeyFile()
         delete [] publicMem;
 
         // read private key;
-        inFile.ReadInt16(len);
+        inFile.ReadInt16((int16_t&)len);
         if (len <= 0 || len > 9000)
         {
             ASSERT(false);
@@ -187,7 +187,7 @@ void cKeyFile::ReadFile(const TCHAR* filename) // throw eKeyFile()
         }
 
         mPrivateKeyMemLen = len;
-        mpPrivateKeyMem   = new int8[len];
+        mpPrivateKeyMem   = new int8_t[len];
         if (inFile.ReadBlob(mpPrivateKeyMem, mPrivateKeyMemLen) < mPrivateKeyMemLen)
         {
             ASSERT(false);
@@ -199,7 +199,7 @@ void cKeyFile::ReadFile(const TCHAR* filename) // throw eKeyFile()
             throw eKeyFileInvalidFmt();
         }
     }
-    catch (eArchive&)
+    catch (const eArchive&)
     {
         delete mpPublicKey;
         delete [] mpPrivateKeyMem;
@@ -208,7 +208,7 @@ void cKeyFile::ReadFile(const TCHAR* filename) // throw eKeyFile()
         mPrivateKeyMemLen = 0;
         throw eKeyFileArchive(filename);
     }
-    catch (eKeyFile&)
+    catch (const eKeyFile&)
     {
         throw;
     }
@@ -240,8 +240,8 @@ void cKeyFile::WriteFile(const TCHAR* filename) const // throw eKeyFile()
         }
 
         // save public key
-        int16 len       = mpPublicKey->GetWriteLen();
-        int8* publicMem = new int8[len];
+        int16_t len       = mpPublicKey->GetWriteLen();
+        int8_t* publicMem = new int8_t[len];
         mpPublicKey->Write(publicMem);
 
         outFile.WriteInt16(len);
@@ -254,7 +254,7 @@ void cKeyFile::WriteFile(const TCHAR* filename) const // throw eKeyFile()
         outFile.WriteInt16(len);
         outFile.WriteBlob(mpPrivateKeyMem, mPrivateKeyMemLen);
     }
-    catch (eArchive&)
+    catch (const eArchive&)
     {
         throw eKeyFileArchive(filename);
     }
@@ -263,33 +263,33 @@ void cKeyFile::WriteFile(const TCHAR* filename) const // throw eKeyFile()
 // Functions to read and write the key to memory.  GetWriteLen() will throw an
 // exception if keys are not currently loaded.
 
-void cKeyFile::ReadMem(const int8* pMem) // throw eKeyFile()
+void cKeyFile::ReadMem(const int8_t* pMem) // throw eKeyFile()
 {
-    int16 i16;
-    int32 i32;
+    int16_t i16;
+    int32_t i32;
 
     ReleaseMem();
 
     memcpy(&i32, pMem, sizeof(i32));
     if ((unsigned int)tw_ntohl(i32) != KEY_MAGIC_NUMBER)
         throw eKeyFileInvalidFmt();
-    pMem += sizeof(int32);
+    pMem += sizeof(int32_t);
 
     memcpy(&i32, pMem, sizeof(i32));
     if (tw_ntohl(i32) != 1) // version check
         throw eKeyFileInvalidFmt();
-    pMem += sizeof(int32);
+    pMem += sizeof(int32_t);
 
     memcpy(&i16, pMem, sizeof(i16));
-    int16 len = tw_ntohs(i16);
+    int16_t len = tw_ntohs(i16);
     if (len <= 0 || len > 9000)
     {
         ASSERT(false);
         throw eKeyFileInvalidFmt();
     }
 
-    mpPublicKey = new cElGamalSigPublicKey((void*)(pMem + sizeof(int16)));
-    pMem += sizeof(int16) + len;
+    mpPublicKey = new cElGamalSigPublicKey((void*)(pMem + sizeof(int16_t)));
+    pMem += sizeof(int16_t) + len;
 
     memcpy(&i16, pMem, sizeof(i16));
     mPrivateKeyMemLen = tw_ntohs(i16);
@@ -301,14 +301,14 @@ void cKeyFile::ReadMem(const int8* pMem) // throw eKeyFile()
         throw eKeyFileInvalidFmt();
     }
 
-    mpPrivateKeyMem = new int8[mPrivateKeyMemLen];
-    memcpy(mpPrivateKeyMem, pMem + sizeof(int16), mPrivateKeyMemLen);
+    mpPrivateKeyMem = new int8_t[mPrivateKeyMemLen];
+    memcpy(mpPrivateKeyMem, pMem + sizeof(int16_t), mPrivateKeyMemLen);
 }
 
-void cKeyFile::WriteMem(int8* pMem) const // throw eKeyFile()
+void cKeyFile::WriteMem(int8_t* pMem) const // throw eKeyFile()
 {
-    int16 i16;
-    int32 i32;
+    int16_t i16;
+    int32_t i32;
 
     if (!KeysLoaded())
     {
@@ -319,17 +319,17 @@ void cKeyFile::WriteMem(int8* pMem) const // throw eKeyFile()
     // magic number and version
     i32 = tw_htonl(KEY_MAGIC_NUMBER);
     memcpy(pMem, &i32, sizeof(i32));
-    pMem += sizeof(int32);
+    pMem += sizeof(int32_t);
 
     i32 = tw_htonl(1);
     memcpy(pMem, &i32, sizeof(i32));
-    pMem += sizeof(int32);
+    pMem += sizeof(int32_t);
 
     // save public key
-    int16 len = mpPublicKey->GetWriteLen();
+    int16_t len = mpPublicKey->GetWriteLen();
     i16       = tw_htons(len);
     memcpy(pMem, &i16, sizeof(i16));
-    pMem += sizeof(int16);
+    pMem += sizeof(int16_t);
 
     mpPublicKey->Write(pMem);
     pMem += len;
@@ -338,12 +338,12 @@ void cKeyFile::WriteMem(int8* pMem) const // throw eKeyFile()
     len = mPrivateKeyMemLen;
     i16 = tw_htons(len);
     memcpy(pMem, &i16, sizeof(i16));
-    pMem += sizeof(int16);
+    pMem += sizeof(int16_t);
 
     memcpy(pMem, mpPrivateKeyMem, mPrivateKeyMemLen);
 }
 
-int cKeyFile::GetWriteLen() // throw eKeyFile()
+int32_t cKeyFile::GetWriteLen() // throw eKeyFile()
 {
     if (!KeysLoaded())
     {
@@ -351,22 +351,22 @@ int cKeyFile::GetWriteLen() // throw eKeyFile()
         throw eKeyFileUninitialized(_T("cKeyFile not initialized"));
     }
 
-    return sizeof(int32) +              // the magic number
-           sizeof(int32) +              // version
-           sizeof(int16) +              // sizeof public key
+    return sizeof(int32_t) +              // the magic number
+           sizeof(int32_t) +              // version
+           sizeof(int16_t) +              // sizeof public key
            mpPublicKey->GetWriteLen() + // the public key
-           sizeof(int16) +              // sizeof private key
+           sizeof(int16_t) +              // sizeof private key
            mPrivateKeyMemLen;           // the private key
 }
 
-void cKeyFile::ProtectKeys(int8* passphrase, int passphraseLen) // throw eKeyFile()
+void cKeyFile::ProtectKeys(int8_t* passphrase, int32_t passphraseLen) // throw eKeyFile()
 {
-    int   i;
-    int16 i16;
+    int     i;
+    int16_t i16;
 
     // generate the hash value of the private key
-    int   len            = mpPrivateKey->GetWriteLen();
-    int8* privateKeyBits = new int8[len];
+    int len                = mpPrivateKey->GetWriteLen();
+    int8_t* privateKeyBits = new int8_t[len];
     mpPrivateKey->Write(privateKeyBits);
     cHashedKey128 privateHash(privateKeyBits, len);
     RandomizeBytes(privateKeyBits, len);
@@ -380,17 +380,17 @@ void cKeyFile::ProtectKeys(int8* passphrase, int passphraseLen) // throw eKeyFil
     ASSERT(des.GetBlockSizeCipher() == des.GetBlockSizePlain());
 
     // calculate size of the memory image of the private key
-    mPrivateKeyMemLen = cHashedKey128::GetWriteLen() + sizeof(int16) + mpPrivateKey->GetWriteLen();
+    mPrivateKeyMemLen = cHashedKey128::GetWriteLen() + sizeof(int16_t) + mpPrivateKey->GetWriteLen();
     mPrivateKeyMemLen = (mPrivateKeyMemLen / des.GetBlockSizePlain() + 1) * des.GetBlockSizePlain();
-    int sluff         = mPrivateKeyMemLen - cHashedKey128::GetWriteLen() - sizeof(int16) - mpPrivateKey->GetWriteLen();
+    int sluff         = mPrivateKeyMemLen - cHashedKey128::GetWriteLen() - sizeof(int16_t) - mpPrivateKey->GetWriteLen();
 
     // write the hash of the private key, the size of the private key, and the private key,
     // all as plaintext.
-    mpPrivateKeyMem = new int8[mPrivateKeyMemLen];
+    mpPrivateKeyMem = new int8_t[mPrivateKeyMemLen];
     privateHash.Write(mpPrivateKeyMem);
     i16 = tw_htons(mpPrivateKey->GetWriteLen());
     memcpy(mpPrivateKeyMem + cHashedKey128::GetWriteLen(), &i16, sizeof(i16));
-    mpPrivateKey->Write(mpPrivateKeyMem + cHashedKey128::GetWriteLen() + sizeof(int16));
+    mpPrivateKey->Write(mpPrivateKeyMem + cHashedKey128::GetWriteLen() + sizeof(int16_t));
 
     RandomizeBytes(mpPrivateKeyMem + mPrivateKeyMemLen - sluff, sluff);
 
@@ -419,7 +419,7 @@ void cKeyFile::ProtectKeys(int8* passphrase, int passphraseLen) // throw eKeyFil
 
 // Generate new keys
 
-void cKeyFile::GenerateKeys(int keySize, int8* passphrase, int passphraseLen) // throw eKeyFile()
+void cKeyFile::GenerateKeys(int keySize, int8_t* passphrase, int passphraseLen) // throw eKeyFile()
 {
     ReleaseMem();
 
@@ -431,10 +431,10 @@ void cKeyFile::GenerateKeys(int keySize, int8* passphrase, int passphraseLen) //
     ProtectKeys(passphrase, passphraseLen);
 }
 
-void cKeyFile::ChangePassphrase(int8* passphraseOld,
-                                int   passphraseOldLen,
-                                int8* passphrase,
-                                int   passphraseLen) // throw eKeyFile()
+void cKeyFile::ChangePassphrase(int8_t* passphraseOld,
+                                int     passphraseOldLen,
+                                int8_t* passphrase,
+                                int     passphraseLen) // throw eKeyFile()
 {
     if (GetPrivateKey(passphraseOld, passphraseOldLen) == 0)
     {
@@ -448,9 +448,9 @@ void cKeyFile::ChangePassphrase(int8* passphraseOld,
 // ReleasePrivateKey() to destory the plaintext version of the key as soon as you
 // are done using the key.
 
-const cElGamalSigPrivateKey* cKeyFile::GetPrivateKey(int8* passphrase, int passphraseLen)
+const cElGamalSigPrivateKey* cKeyFile::GetPrivateKey(int8_t* passphrase, int passphraseLen)
 {
-    int16 i16;
+    int16_t i16;
 
     if (!KeysLoaded())
     {
@@ -470,13 +470,12 @@ const cElGamalSigPrivateKey* cKeyFile::GetPrivateKey(int8* passphrase, int passp
         ASSERT(des.GetBlockSizeCipher() == des.GetBlockSizePlain());
 
         // get a copy of the ciphertext and decrypt it
-        int8* plainPrivateKeyMem = new int8[mPrivateKeyMemLen];
+        uint8_t* plainPrivateKeyMem = new uint8_t[mPrivateKeyMemLen];
         memcpy(plainPrivateKeyMem, mpPrivateKeyMem, mPrivateKeyMemLen);
 
         ASSERT(mPrivateKeyMemLen % des.GetBlockSizePlain() == 0);
 
-        int i;
-        for (i = 0; i < mPrivateKeyMemLen; i += des.GetBlockSizePlain())
+        for (int i = 0; i < mPrivateKeyMemLen; i += des.GetBlockSizePlain())
         {
             des.ProcessBlock(plainPrivateKeyMem + i, plainPrivateKeyMem + i);
         }
@@ -485,29 +484,29 @@ const cElGamalSigPrivateKey* cKeyFile::GetPrivateKey(int8* passphrase, int passp
         memcpy(&i16, plainPrivateKeyMem + cHashedKey128::GetWriteLen(), sizeof(i16));
         int len = tw_ntohs(i16);
 
-        if (len + cHashedKey128::GetWriteLen() + sizeof(int16) > (unsigned int)mPrivateKeyMemLen)
+        if (len + cHashedKey128::GetWriteLen() + sizeof(int16_t) > (unsigned int)mPrivateKeyMemLen)
         {
-            RandomizeBytes(plainPrivateKeyMem, mPrivateKeyMemLen);
+            RandomizeBytes((int8_t*)plainPrivateKeyMem, mPrivateKeyMemLen);
             delete [] plainPrivateKeyMem;
             RandomizeBytes(passphrase, passphraseLen);
             return 0;
         }
 
-        cHashedKey128 privateHash(plainPrivateKeyMem + cHashedKey128::GetWriteLen() + sizeof(int16), len);
+        cHashedKey128 privateHash(plainPrivateKeyMem + cHashedKey128::GetWriteLen() + sizeof(int16_t), len);
 
         // compare to the stored value
         if (memcmp(plainPrivateKeyMem, privateHash.GetKey(), cHashedKey128::GetWriteLen()) != 0)
         {
             // passphrase didn't do the job
-            RandomizeBytes(plainPrivateKeyMem, mPrivateKeyMemLen);
+            RandomizeBytes((int8_t*)plainPrivateKeyMem, mPrivateKeyMemLen);
             delete [] plainPrivateKeyMem;
             RandomizeBytes(passphrase, passphraseLen);
             return 0;
         }
 
-        mpPrivateKey = new cElGamalSigPrivateKey(plainPrivateKeyMem + cHashedKey128::GetWriteLen() + sizeof(int16));
+        mpPrivateKey = new cElGamalSigPrivateKey(plainPrivateKeyMem + cHashedKey128::GetWriteLen() + sizeof(int16_t));
 
-        RandomizeBytes(plainPrivateKeyMem, mPrivateKeyMemLen);
+        RandomizeBytes((int8_t*)plainPrivateKeyMem, mPrivateKeyMemLen);
         delete [] plainPrivateKeyMem;
 
         RandomizeBytes(passphrase, passphraseLen);
@@ -552,7 +551,7 @@ const cElGamalSigPublicKey* cKeyFile::GetPublicKey() const // throw eKeyFile()
 ///////////////////////////////////////////////////////////////////////////////
 // class cPrivateKeyProxy
 
-bool cPrivateKeyProxy::AquireKey(cKeyFile& keyFile, int8* passphrase, int passphraseLen)
+bool cPrivateKeyProxy::AquireKey(cKeyFile& keyFile, int8_t* passphrase, int passphraseLen)
 {
     if (mpKey != 0)
     {

--- a/src/twcrypto/keyfile.cpp
+++ b/src/twcrypto/keyfile.cpp
@@ -343,7 +343,7 @@ void cKeyFile::WriteMem(int8_t* pMem) const // throw eKeyFile()
     memcpy(pMem, mpPrivateKeyMem, mPrivateKeyMemLen);
 }
 
-int32_t cKeyFile::GetWriteLen() // throw eKeyFile()
+int cKeyFile::GetWriteLen() // throw eKeyFile()
 {
     if (!KeysLoaded())
     {
@@ -359,7 +359,7 @@ int32_t cKeyFile::GetWriteLen() // throw eKeyFile()
            mPrivateKeyMemLen;           // the private key
 }
 
-void cKeyFile::ProtectKeys(int8_t* passphrase, int32_t passphraseLen) // throw eKeyFile()
+void cKeyFile::ProtectKeys(int8_t* passphrase, int passphraseLen) // throw eKeyFile()
 {
     int     i;
     int16_t i16;
@@ -470,7 +470,7 @@ const cElGamalSigPrivateKey* cKeyFile::GetPrivateKey(int8_t* passphrase, int pas
         ASSERT(des.GetBlockSizeCipher() == des.GetBlockSizePlain());
 
         // get a copy of the ciphertext and decrypt it
-        uint8_t* plainPrivateKeyMem = new uint8_t[mPrivateKeyMemLen];
+        int8_t* plainPrivateKeyMem = new int8_t[mPrivateKeyMemLen];
         memcpy(plainPrivateKeyMem, mpPrivateKeyMem, mPrivateKeyMemLen);
 
         ASSERT(mPrivateKeyMemLen % des.GetBlockSizePlain() == 0);
@@ -486,7 +486,7 @@ const cElGamalSigPrivateKey* cKeyFile::GetPrivateKey(int8_t* passphrase, int pas
 
         if (len + cHashedKey128::GetWriteLen() + sizeof(int16_t) > (unsigned int)mPrivateKeyMemLen)
         {
-            RandomizeBytes((int8_t*)plainPrivateKeyMem, mPrivateKeyMemLen);
+            RandomizeBytes(plainPrivateKeyMem, mPrivateKeyMemLen);
             delete [] plainPrivateKeyMem;
             RandomizeBytes(passphrase, passphraseLen);
             return 0;
@@ -498,7 +498,7 @@ const cElGamalSigPrivateKey* cKeyFile::GetPrivateKey(int8_t* passphrase, int pas
         if (memcmp(plainPrivateKeyMem, privateHash.GetKey(), cHashedKey128::GetWriteLen()) != 0)
         {
             // passphrase didn't do the job
-            RandomizeBytes((int8_t*)plainPrivateKeyMem, mPrivateKeyMemLen);
+            RandomizeBytes(plainPrivateKeyMem, mPrivateKeyMemLen);
             delete [] plainPrivateKeyMem;
             RandomizeBytes(passphrase, passphraseLen);
             return 0;
@@ -506,7 +506,7 @@ const cElGamalSigPrivateKey* cKeyFile::GetPrivateKey(int8_t* passphrase, int pas
 
         mpPrivateKey = new cElGamalSigPrivateKey(plainPrivateKeyMem + cHashedKey128::GetWriteLen() + sizeof(int16_t));
 
-        RandomizeBytes((int8_t*)plainPrivateKeyMem, mPrivateKeyMemLen);
+        RandomizeBytes(plainPrivateKeyMem, mPrivateKeyMemLen);
         delete [] plainPrivateKeyMem;
 
         RandomizeBytes(passphrase, passphraseLen);

--- a/src/twcrypto/keyfile.h
+++ b/src/twcrypto/keyfile.h
@@ -72,26 +72,26 @@ public:
     void WriteFile(const TCHAR* filename) const; // throw eKeyFile()
         // Read and write keys to a keyfile
 
-    void ReadMem(const int8* pMem);  // throw eKeyFile()
-    void WriteMem(int8* pMem) const; // throw eKeyFile()
-    int  GetWriteLen();              // throw eKeyFile()
+    void ReadMem(const int8_t* pMem);  // throw eKeyFile()
+    void WriteMem(int8_t* pMem) const; // throw eKeyFile()
+    int GetWriteLen();              // throw eKeyFile()
         // Functions to read and write the key to memory.  GetWriteLen() will throw an
         // exception if keys are not currently loaded.
 
     bool KeysLoaded() const;
 
-    void GenerateKeys(int keySize, int8* passphrase, int passphraseLen); // throw eKeyFile()
+    void GenerateKeys(int keySize, int8_t* passphrase, int passphraseLen); // throw eKeyFile()
         // Generate new keys
         // Note: Bytes in passphrase will be cleared after keys are generated for safety
 
-    void ChangePassphrase(int8* passphraseOld,
-                          int   passphraseOldLen,
-                          int8* passphrase,
-                          int   passphraseLen); // throw eKeyFile()
+    void ChangePassphrase(int8_t* passphraseOld,
+                          int     passphraseOldLen,
+                          int8_t* passphrase,
+                          int     passphraseLen); // throw eKeyFile()
     // Change passphrase
     // Note: Bytes in passphrases will be cleared after change for safety
 
-    const cElGamalSigPrivateKey* GetPrivateKey(int8* passphrase, int passphraseLen);
+    const cElGamalSigPrivateKey* GetPrivateKey(int8_t* passphrase, int passphraseLen);
     void                         ReleasePrivateKey();
     // Access to the private key.  Key is normally stored encrypted for safety.  Call
     // ReleasePrivateKey() to destory the plaintext version of the key as soon as you
@@ -103,8 +103,8 @@ public:
     static const cFileHeaderID& GetFileHeaderID();
 
 protected:
-    int8* mpPrivateKeyMem; // encrypted version of private key
-    int   mPrivateKeyMemLen;
+    int8_t* mpPrivateKeyMem; // encrypted version of private key
+    int     mPrivateKeyMemLen;
 
     cElGamalSigPrivateKey* mpPrivateKey; // only valid between calls to GetPrivateKey() and ReleasePrivateKey()
     cElGamalSigPublicKey*  mpPublicKey;
@@ -112,7 +112,7 @@ protected:
     int mPrivateKeyUseCount;
 
 private:
-    void ProtectKeys(int8* passphrase, int passphraseLen); // throw eKeyFile()
+    void ProtectKeys(int8_t* passphrase, int passphraseLen); // throw eKeyFile()
     void ReleaseMem();
 };
 
@@ -129,7 +129,7 @@ public:
     cPrivateKeyProxy();
     ~cPrivateKeyProxy();
 
-    bool AquireKey(cKeyFile& keyFile, int8* passphrase, int passphraseLen);
+    bool AquireKey(cKeyFile& keyFile, int8_t* passphrase, int passphraseLen);
     // note: be sure to check return value for failure!!!
 
     bool Valid() const

--- a/src/twcrypto/keyfile.h
+++ b/src/twcrypto/keyfile.h
@@ -74,7 +74,7 @@ public:
 
     void ReadMem(const int8_t* pMem);  // throw eKeyFile()
     void WriteMem(int8_t* pMem) const; // throw eKeyFile()
-    int GetWriteLen();              // throw eKeyFile()
+    int  GetWriteLen();              // throw eKeyFile()
         // Functions to read and write the key to memory.  GetWriteLen() will throw an
         // exception if keys are not currently loaded.
 

--- a/src/twtest/archive_t.cpp
+++ b/src/twtest/archive_t.cpp
@@ -62,8 +62,8 @@ void TestMemoryArchive()
 
     memarch.Seek(0, cBidirArchive::BEGINNING);
 
-    int32 i;
-    int64 l;
+    int32_t i;
+    int64_t l;
     memarch.ReadInt32(i);
     TEST(i == 1);
     memarch.ReadInt32(i);
@@ -80,7 +80,7 @@ void TestMemoryArchive()
     memarch.ReadInt64(l);
     TEST(l == 1234567L);
 
-    TEST(memarch.ReadBlob(NULL, sizeof(int16)) == sizeof(int16));
+    TEST(memarch.ReadBlob(NULL, sizeof(int16_t)) == sizeof(int16_t));
     TEST(memarch.ReadBlob(NULL, 1024) == 0);
 
     try
@@ -99,10 +99,10 @@ void TestMemoryArchive()
         (void)e;
     }
 
-    memarch.MapArchive(4 * sizeof(int32) + sizeof(int32) + 6, sizeof(int64));
-    TEST(memarch.GetMappedOffset() == 4 * sizeof(int32) + sizeof(int32) + 6);
-    TEST(memarch.GetMappedLength() == sizeof(int64));
-    //    TEST(tw_ntohll(*(int64*)memarch.GetMap()) == 1234567L);
+    memarch.MapArchive(4 * sizeof(int32_t) + sizeof(int32_t) + 6, sizeof(int64_t));
+    TEST(memarch.GetMappedOffset() == 4 * sizeof(int32_t) + sizeof(int32_t) + 6);
+    TEST(memarch.GetMappedLength() == sizeof(int64_t));
+    //    TEST(tw_ntohll(*(int64_t*)memarch.GetMap()) == 1234567L);
 }
 
 void TestLockedTemporaryArchive()
@@ -186,8 +186,8 @@ void TestFileArchive()
     filearch.WriteInt16(42);
     filearch.Close();
 
-    int32 j;
-    int64 k;
+    int32_t j;
+    int64_t k;
     filearch.OpenRead(fileName.c_str());
     filearch.Seek(0, cBidirArchive::BEGINNING);
     filearch.ReadInt32(j);
@@ -205,7 +205,7 @@ void TestFileArchive()
     filearch.ReadInt64(k);
     TEST(k == 1234567L);
 
-    TEST(filearch.ReadBlob(NULL, sizeof(int16)) == sizeof(int16));
+    TEST(filearch.ReadBlob(NULL, sizeof(int16_t)) == sizeof(int16_t));
     TEST(filearch.ReadBlob(NULL, 1024) == 0); // should be EOF
 
     try

--- a/src/twtest/blockrecordarray_t.cpp
+++ b/src/twtest/blockrecordarray_t.cpp
@@ -73,13 +73,13 @@ void TestBlockRecordArray()
     static const char data2[] = "And here we have data 2";
     static const char data3[] = "Here is d a t a 3!";
     static const char data4[] = "Three cheers for data 4!";
-    ra1.AddItem((int8*)data1, sizeof(data1), 1);
+    ra1.AddItem((int8_t*)data1, sizeof(data1), 1);
     //    TEST(ra1.IsItemValid(1));
-    ra1.AddItem((int8*)data2, sizeof(data2), 2);
+    ra1.AddItem((int8_t*)data2, sizeof(data2), 2);
     //    TEST(ra1.IsItemValid(2));
-    ra1.AddItem((int8*)data3, sizeof(data3), 3);
+    ra1.AddItem((int8_t*)data3, sizeof(data3), 3);
     //    TEST(ra1.IsItemValid(3));
-    ra1.AddItem((int8*)data4, sizeof(data4), 4);
+    ra1.AddItem((int8_t*)data4, sizeof(data4), 4);
     //    TEST(ra1.IsItemValid(4));
 #ifdef _BLOCKFILE_DEBUG
     ra1.TraceContents();
@@ -97,7 +97,7 @@ void TestBlockRecordArray()
 
     // add a new item...
     static const char data5[] = "fffiiivvveee!";
-    ra1.AddItem((int8*)data5, sizeof(data5), 5);
+    ra1.AddItem((int8_t*)data5, sizeof(data5), 5);
     //    TEST(ra1.IsItemValid(5));
 #ifdef _BLOCKFILE_DEBUG
     ra1.TraceContents();
@@ -125,8 +125,8 @@ void TestBlockRecordArray()
     // add a couple more just for kicks :-)
     static const char data6[] = "We're looking for six";
     static const char data7[] = "All 7s go to heaven";
-    ra1.AddItem((int8*)data6, sizeof(data6), 6);
-    ra1.AddItem((int8*)data7, sizeof(data7), 7);
+    ra1.AddItem((int8_t*)data6, sizeof(data6), 6);
+    ra1.AddItem((int8_t*)data7, sizeof(data7), 7);
 #ifdef _BLOCKFILE_DEBUG
     ra1.TraceContents();
 #endif

--- a/src/twtest/cryptoarchive_t.cpp
+++ b/src/twtest/cryptoarchive_t.cpp
@@ -49,7 +49,7 @@ void TestCryptoArchive()
 
     d.TraceDetail("Building test memory image of size %dK bytes\n", SIZEOF_CHUNK * NUM_CHUNKS / 1024);
 
-    int8 chunk[7];
+    int8_t chunk[7];
     memcpy(chunk, "1234567", 7);
 
     int i;
@@ -78,7 +78,7 @@ void TestCryptoArchive()
 
         for (memory.Seek(0, cBidirArchive::BEGINNING); !memory.EndOfFile();)
         {
-            int8 buf[SIZEOF_CHUNK];
+            int8_t buf[SIZEOF_CHUNK];
             memory.ReadBlob(buf, SIZEOF_CHUNK);
             outCrypt.WriteBlob(buf, SIZEOF_CHUNK);
         }
@@ -99,7 +99,7 @@ void TestCryptoArchive()
         int index;
         for (index = 0; index < NUM_CHUNKS * SIZEOF_CHUNK; index += TEST_CHUNKSIZE)
         {
-            int8 buf[TEST_CHUNKSIZE];
+            int8_t buf[TEST_CHUNKSIZE];
 
             int s = (index + TEST_CHUNKSIZE <= NUM_CHUNKS * SIZEOF_CHUNK) ? TEST_CHUNKSIZE :
                                                                             NUM_CHUNKS * SIZEOF_CHUNK - index;
@@ -135,7 +135,7 @@ void TestCryptoArchive()
 
             for (memory.Seek(0, cBidirArchive::BEGINNING); !memory.EndOfFile();)
             {
-                int8 buf[SIZEOF_CHUNK];
+                int8_t buf[SIZEOF_CHUNK];
                 memory.ReadBlob(buf, SIZEOF_CHUNK);
                 outCrypt.WriteBlob(buf, SIZEOF_CHUNK);
             }
@@ -156,7 +156,7 @@ void TestCryptoArchive()
             int index;
             for (index = 0; index < NUM_CHUNKS * SIZEOF_CHUNK; index += TEST_CHUNKSIZE)
             {
-                int8 buf[TEST_CHUNKSIZE];
+                int8_t buf[TEST_CHUNKSIZE];
 
                 int s = (index + TEST_CHUNKSIZE <= NUM_CHUNKS * SIZEOF_CHUNK) ? TEST_CHUNKSIZE :
                                                                                 NUM_CHUNKS * SIZEOF_CHUNK - index;
@@ -187,7 +187,7 @@ void TestCryptoArchive()
 
     d.TraceDetail("Building test memory image of size %dK bytes\n", SIZEOF_CHUNK * NUM_CHUNKS / 1024);
 
-    int8 chunk[7];
+    int8_t chunk[7];
     memcpy(chunk, "1234567", 7);
 
     int i;
@@ -211,7 +211,7 @@ void TestCryptoArchive()
 
         for (memory.Seek(0, cBidirArchive::BEGINNING); !memory.EndOfFile();)
         {
-            int8 buf[SIZEOF_CHUNK];
+            int8_t buf[SIZEOF_CHUNK];
             memory.ReadBlob(buf, SIZEOF_CHUNK);
             outCrypt.WriteBlob(buf, SIZEOF_CHUNK);
         }
@@ -232,7 +232,7 @@ void TestCryptoArchive()
         int index;
         for (index = 0; index < NUM_CHUNKS * SIZEOF_CHUNK; index += TEST_CHUNKSIZE)
         {
-            int8 buf[TEST_CHUNKSIZE];
+            int8_t buf[TEST_CHUNKSIZE];
 
             int s = (index + TEST_CHUNKSIZE <= NUM_CHUNKS * SIZEOF_CHUNK) ? TEST_CHUNKSIZE :
                                                                             NUM_CHUNKS * SIZEOF_CHUNK - index;
@@ -256,7 +256,7 @@ void TestCryptoArchive()
 
         for (memory.Seek(0, cBidirArchive::BEGINNING); !memory.EndOfFile();)
         {
-            int8 buf[SIZEOF_CHUNK];
+            int8_t buf[SIZEOF_CHUNK];
             memory.ReadBlob(buf, SIZEOF_CHUNK);
             outCrypt.WriteBlob(buf, SIZEOF_CHUNK);
         }
@@ -277,7 +277,7 @@ void TestCryptoArchive()
         int index;
         for (index = 0; index < NUM_CHUNKS * SIZEOF_CHUNK; index += TEST_CHUNKSIZE)
         {
-            int8 buf[TEST_CHUNKSIZE];
+            int8_t buf[TEST_CHUNKSIZE];
 
             int s = (index + TEST_CHUNKSIZE <= NUM_CHUNKS * SIZEOF_CHUNK) ? TEST_CHUNKSIZE :
                                                                             NUM_CHUNKS * SIZEOF_CHUNK - index;

--- a/src/twtest/fcopropimpl_t.cpp
+++ b/src/twtest/fcopropimpl_t.cpp
@@ -54,7 +54,7 @@ void TestNumeric()
     pi64.SetValue(-456);
     pui64.SetValue(456);
     pui64b.SetValue(333);
-    d.TraceDebug(_T("property int64 = (should be -456) %s\n"), pi64.AsString().c_str());
+    d.TraceDebug(_T("property int64_t = (should be -456) %s\n"), pi64.AsString().c_str());
     TEST(pi64.AsString() == "-456");
 
     // test a few operators

--- a/src/twtest/fcoreport_t.cpp
+++ b/src/twtest/fcoreport_t.cpp
@@ -127,7 +127,7 @@ void TestFCOReport()
         /*
         //Store the time taken to generate the test report:
         time_finish = time(dummy_arg);
-        report.SetCreationTime( (int64)difftime(time_finish, time_begin));
+        report.SetCreationTime( (int64_t)difftime(time_finish, time_begin));
         d.TraceDebug("Report calculation time = %I64i seconds.\n", report.GetCreationTime());
         */
 

--- a/src/twtest/fspropcalc_t.cpp
+++ b/src/twtest/fspropcalc_t.cpp
@@ -154,7 +154,7 @@ void TestGetSymLinkStr()
 
     cMemoryArchive arch(1024 * 1024);
     TEST(cFSPropCalc::GetSymLinkStr(link, arch, 8));
-    TEST(arch.Length() == (int64)file.size());
+    TEST(arch.Length() == (int64_t)file.size());
 }
 
 void RegisterSuite_FSPropCalc()

--- a/src/twtest/hierdatabase_t.cpp
+++ b/src/twtest/hierdatabase_t.cpp
@@ -48,7 +48,7 @@ static void AddFile(cHierDatabase::iterator& iter, const TSTRING& filename, bool
 
     if (with_data)
     {
-        iter.SetData((int8*)g_block_data.c_str(), g_block_data.length() + 1);
+        iter.SetData((int8_t*)g_block_data.c_str(), g_block_data.length() + 1);
     }
 
     TEST(iter.HasData() == with_data);
@@ -139,7 +139,7 @@ static void AssertData(cHierDatabase::iterator& iter, const TSTRING& filename, b
 
         if (has_data)
         {
-            int32   dummyLength;
+            int32_t   dummyLength;
             TSTRING read_str((TCHAR*)iter.GetData(dummyLength));
             TEST(read_str == g_block_data);
         }

--- a/src/twtest/keyfile_t.cpp
+++ b/src/twtest/keyfile_t.cpp
@@ -59,7 +59,7 @@ void TestKeyFile()
 
     d.TraceDebug("Generating keys...\n");
     std::string s = "haybaby";
-    keyfile.GenerateKeys(cElGamalSig::KEY1024, (int8*)s.data(), 7);
+    keyfile.GenerateKeys(cElGamalSig::KEY1024, (int8_t*)s.data(), 7);
 
     char plaintext[9000];
     char ciphertext[9000];
@@ -74,7 +74,7 @@ void TestKeyFile()
         TEST(elGamal.GetBlockSizeCipher() < 9000);
         std::string      s = "haybaby";
         cPrivateKeyProxy key;
-        TEST(key.AquireKey(keyfile, (int8*)s.data(), 7));
+        TEST(key.AquireKey(keyfile, (int8_t*)s.data(), 7));
         elGamal.SetSigning(key.GetKey());
         elGamal.ProcessBlock(plaintext, ciphertext);
     }
@@ -94,7 +94,7 @@ void TestKeyFile()
     // save to and read from memory
     d.TraceDebug("Read/Write to memory...\n");
     {
-        int8* pMem = new int8[keyfile.GetWriteLen()];
+        int8_t* pMem = new int8_t[keyfile.GetWriteLen()];
         keyfile.WriteMem(pMem);
 
         cKeyFile keyfile2;

--- a/src/twtest/platform_t.cpp
+++ b/src/twtest/platform_t.cpp
@@ -68,7 +68,7 @@ public:
     AlignMe();
 
 private:
-    uint8_t a[sizeof(int64) + ALIGN_SIZE]; // we want to be able to access a int64 at address [ALIGN_SIZE]
+    uint8_t a[sizeof(int64_t) + ALIGN_SIZE]; // we want to be able to access a int64_t at address [ALIGN_SIZE]
 };
 
 /////////////////////////////////////////////////////////
@@ -91,10 +91,10 @@ template<int ALIGN_SIZE> AlignMe<ALIGN_SIZE>::AlignMe()
 
     // this should choke if the CPU can't
     // handle misaligned memory access
-    int32* pi = (int32*)&a[ALIGN_SIZE];
+    int32_t* pi = (int32_t*)&a[ALIGN_SIZE];
     //TCOUT << _T("Testing alignment of an int32...") << std::endl;
     //TCOUT << _T("Reading...") << std::endl;
-    int32 i = *pi; // access memory for read
+    int32_t i = *pi; // access memory for read
     //TCOUT << _T("Read succeeded.") << std::endl;
     //TCOUT << _T("Writing...") << std::endl;
     *pi = i; // access memory for write
@@ -103,10 +103,10 @@ template<int ALIGN_SIZE> AlignMe<ALIGN_SIZE>::AlignMe()
 
     // this should choke if the CPU can't
     // handle misaligned memory access
-    int64* pb = (int64*)&a[ALIGN_SIZE];
+    int64_t* pb = (int64_t*)&a[ALIGN_SIZE];
     //TCOUT << _T("Testing alignment of an int64...") << std::endl;
     //TCOUT << _T("Reading...") << std::endl;
-    int64 I = *pb; // access memory for read
+    int64_t I = *pb; // access memory for read
     //TCOUT << _T("Read succeeded") << std::endl;
     //TCOUT << _T("Writing...") << std::endl;
     *pb = I; // access memory for write
@@ -152,7 +152,7 @@ void TestAlignment()
     // such accesses: it may have handled the
     // hardware interrupt that might have occured.
     // - - - - - - - - - - - - - - - - - - - - - -
-    uint8_t a[sizeof(int32) + sizeof(uint8_t)];
+    uint8_t a[sizeof(int32_t) + sizeof(uint8_t)];
 
     // this should be fine
     a[0] = 0xAB;
@@ -165,7 +165,7 @@ void TestAlignment()
 
     // this should choke if the CPU can't
     // handle misaligned memory access
-    int32* pi = (int32*)&a[1];
+    int32_t* pi = (int32_t*)&a[1];
     *pi       = *pi; // misaligned access (read and write)
 
     TCOUT << _T("Misaligned access OK.") << std::endl;
@@ -190,7 +190,7 @@ void TestAlignment()
 */
     // this should choke if the CPU can't
     // handle misaligned memory access
-    pi  = (int32*)&b[BYTE_ALIGN];
+    pi  = (int32_t*)&b[BYTE_ALIGN];
     *pi = *pi; // aligned (hopefully) access (read and write)
 
     /*    TCOUT << _T("Aligned access OK.  BYTE_ALIGN value of ") << BYTE_ALIGN << _T(" is good.") << std::endl;
@@ -202,18 +202,18 @@ void TestAlignment()
 // work the way we think they do.
 void TestSizes()
 {
-    TEST(CanBeRepresentedAs(int8(), int8()));
-    TEST(!CanBeRepresentedAs(int8(), uint8()));
-    TEST(!CanBeRepresentedAs(uint8(), int8()));
-    TEST(CanBeRepresentedAs(uint8(), uint8()));
+    TEST(CanBeRepresentedAs(int8_t(),   int8_t()));
+    TEST(!CanBeRepresentedAs(int8_t(),  uint8_t()));
+    TEST(!CanBeRepresentedAs(uint8_t(), int8_t()));
+    TEST(CanBeRepresentedAs(uint8_t(),  uint8_t()));
 
-    TEST(CanBeRepresentedAs(int8(), int16()));
-    TEST(CanBeRepresentedAs(int16(), int32()));
-    TEST(CanBeRepresentedAs(int32(), int64()));
+    TEST(CanBeRepresentedAs(int8_t(),   int16_t()));
+    TEST(CanBeRepresentedAs(int16_t(),  int32_t()));
+    TEST(CanBeRepresentedAs(int32_t(),  int64_t()));
 
-    TEST(CanBeRepresentedAs(uint8(), uint16()));
-    TEST(CanBeRepresentedAs(uint16(), uint32()));
-    TEST(CanBeRepresentedAs(uint32(), uint64()));
+    TEST(CanBeRepresentedAs(uint8_t(),  uint16_t()));
+    TEST(CanBeRepresentedAs(uint16_t(), uint32_t()));
+    TEST(CanBeRepresentedAs(uint32_t(), uint64_t()));
 }
 
 /////////////////////////////////////////////////////////

--- a/src/twtest/refcountobj_t.cpp
+++ b/src/twtest/refcountobj_t.cpp
@@ -48,7 +48,7 @@ private:
     virtual ~cRefCountTestObj();
 
     std::list<cRefCountTestObj*> mChildren;
-    int8*                        mpSomeMem;
+    int8_t*                      mpSomeMem;
 };
 
 cRefCountTestObj::cRefCountTestObj()
@@ -56,7 +56,7 @@ cRefCountTestObj::cRefCountTestObj()
     // allocate some mem that should be caught
     // by the memory manager if this object does not
     // get destructed.
-    mpSomeMem = new int8[10];
+    mpSomeMem = new int8_t[10];
 }
 
 cRefCountTestObj::~cRefCountTestObj()

--- a/src/twtest/serializer_t.cpp
+++ b/src/twtest/serializer_t.cpp
@@ -54,7 +54,7 @@ public:
     cSerTestObject();
 
     // iSerializable interface
-    virtual void Read(iSerializer* pSerializer, int32 version = 0)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0)
     {
     }
     virtual void Write(iSerializer* pSerializer) const

--- a/src/twtest/serializerimpl_t.cpp
+++ b/src/twtest/serializerimpl_t.cpp
@@ -47,7 +47,7 @@ public:
     cSerializerTestObject();
 
     // iSerializable interface
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 
     bool CheckValid();
@@ -83,7 +83,7 @@ bool cSerializerTestObject::CheckValid()
     return true;
 }
 
-void cSerializerTestObject::Read(iSerializer* pSerializer, int32 version)
+void cSerializerTestObject::Read(iSerializer* pSerializer, int32_t version)
 {
     if (version > Version())
         ThrowAndAssert(eSerializerVersionMismatch(_T("cSerializerTestObject::Read()")));
@@ -92,7 +92,7 @@ void cSerializerTestObject::Read(iSerializer* pSerializer, int32 version)
     mNumber = 0;
     memset(mData, 0, 20);
     mString.erase();
-    int32 number;
+    int32_t number;
     pSerializer->ReadInt32(number);
     pSerializer->ReadBlob(mData, 20);
     pSerializer->ReadString(mString);

--- a/src/twtest/srefcountobj_t.cpp
+++ b/src/twtest/srefcountobj_t.cpp
@@ -53,7 +53,7 @@ protected:
     ~cSerRefCountObjTest();
 
     // iSerializable interface
-    virtual void Read(iSerializer* pSerializer, int32 version = 0); // throw (eSerializer, eArchive)
+    virtual void Read(iSerializer* pSerializer, int32_t version = 0); // throw (eSerializer, eArchive)
     virtual void Write(iSerializer* pSerializer) const;             // throw (eSerializer, eArchive)
 
 private:
@@ -73,12 +73,12 @@ cSerRefCountObjTest::~cSerRefCountObjTest()
 }
 
 
-void cSerRefCountObjTest::Read(iSerializer* pSerializer, int32 version)
+void cSerRefCountObjTest::Read(iSerializer* pSerializer, int32_t version)
 {
     if (version > Version())
         ThrowAndAssert(eSerializerVersionMismatch(_T("cSerRefCountObjTest::Read()")));
 
-    int32 dummy;
+    int32_t dummy;
     pSerializer->ReadInt32(dummy);
     mDummyData = dummy;
 }

--- a/src/twtest/twlocale_t.cpp
+++ b/src/twtest/twlocale_t.cpp
@@ -70,7 +70,7 @@ void TestItoa()
         //
         // setup
         //
-        int32   n = 123456;
+        int32_t   n = 123456;
         TSTRING str;
 
         //

--- a/src/twtest/twlocale_t.cpp
+++ b/src/twtest/twlocale_t.cpp
@@ -70,7 +70,7 @@ void TestItoa()
         //
         // setup
         //
-        int32_t   n = 123456;
+        int32_t n = 123456;
         TSTRING str;
 
         //

--- a/src/twtest/types_t.cpp
+++ b/src/twtest/types_t.cpp
@@ -39,16 +39,14 @@
 // TestTypes() -- this will simply make sure that all the types are defined properly for the current build
 void TestTypes()
 {
-    TEST(sizeof(int8) == 1);
-    TEST(sizeof(uint8) == 1);
-    TEST(sizeof(int16) == 2);
-    TEST(sizeof(uint16) == 2);
-    TEST(sizeof(int32) == 4);
-    TEST(sizeof(uint32) == 4);
-    TEST(sizeof(int64) == 8);
-    TEST(sizeof(uint64) == 8);
-    TEST(sizeof(float32) == 4);
-    TEST(sizeof(float64) == 8);
+    TEST(sizeof(int8_t) == 1);
+    TEST(sizeof(uint8_t) == 1);
+    TEST(sizeof(int16_t) == 2);
+    TEST(sizeof(uint16_t) == 2);
+    TEST(sizeof(int32_t) == 4);
+    TEST(sizeof(uint32_t) == 4);
+    TEST(sizeof(int64_t) == 8);
+    TEST(sizeof(uint64_t) == 8);
 }
 
 void RegisterSuite_Types()

--- a/src/twtest/unixfsservices_t.cpp
+++ b/src/twtest/unixfsservices_t.cpp
@@ -170,7 +170,7 @@ void TestGetCurrentUserName()
 
 void TestGetIPAddress()
 {
-    uint32 ipaddr;
+    uint32_t ipaddr;
     bool   success = iFSServices::GetInstance()->GetIPAddress(ipaddr);
     if (!success)
         skip("GetIPAddress test skipped, usually caused by hostname/IP configuration problems");

--- a/src/util/fileutil.cpp
+++ b/src/util/fileutil.cpp
@@ -243,7 +243,7 @@ bool cFileUtil::Copy(const TSTRING& src_path, const TSTRING& dest_path)
     {
         BUF_SIZE = 4096
     };
-    int8 buf[BUF_SIZE];
+    int8_t buf[BUF_SIZE];
     int  nBytesRead;
 
     cFile srcFile, destFile;


### PR DESCRIPTION
This PR switches us to use the standard fixed-width integer types (int8_t, uint32_t, etc.) instead of rolling our own (which we were doing because stdint.h / cstdint didn't exist back in 1998).  This is mostly an aesthetic change, but it's one less thing to go awry at configure time.

Couple of other minor small tweaks:
* cArchive::Write() takes a const string reference instead of a string by value
* Catch some exceptions by const reference instead of nonconst reference in keyfile.cpp
* Change return type of cErrorQueue::GetNumErrors()
